### PR TITLE
Change default PermGen from 64 to 128 mb

### DIFF
--- a/MultiMC.cpp
+++ b/MultiMC.cpp
@@ -511,7 +511,7 @@ void MultiMC::initGlobalSettings(bool test_mode)
 	// Memory
 	m_settings->registerSetting({"MinMemAlloc", "MinMemoryAlloc"}, 512);
 	m_settings->registerSetting({"MaxMemAlloc", "MaxMemoryAlloc"}, 1024);
-	m_settings->registerSetting("PermGen", 64);
+	m_settings->registerSetting("PermGen", 128);
 
 	// Java Settings
 	m_settings->registerSetting("JavaPath", "");


### PR DESCRIPTION
This will help users who run mods. Too many issues have been made over the lack of more permgen being assigned.