### PR TITLE
NOISSUE Add cmake format target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ include(Coverity)
 
 ############################### Built Artifacts ###############################
 
+include(Format)
+
 add_subdirectory(tests)
 
 add_subdirectory(logic)

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -303,6 +303,8 @@ set(MULTIMC_QRCS
 	resources/certs/certs.qrc
 )
 
+Format(Application ${MULTIMC_SOURCES})
+
 ######## Windows resource files ########
 if(WIN32)
 	set(MULTIMC_RCS resources/multimc.rc)

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -5,23 +5,24 @@ set(FILES_TO_FORMAT)
 add_custom_target(format)
 
 function(Format NAME)
+    if(EXISTS ${CLANGFORMAT_PATH})
+        add_custom_target(format-${NAME})
 
-    add_custom_target(format-${NAME})
-
-    foreach(infile ${ARGN})
-        get_filename_component(dir ${infile} DIRECTORY)
-        if(NOT "${dir}" STREQUAL "${PROJECT_BINARY_DIR}")
-            set(FILES_TO_FORMAT ${FILES_TO_FORMAT} ${infile})
-        endif()
-    endforeach()
+        foreach(infile ${ARGN})
+            get_filename_component(dir ${infile} DIRECTORY)
+            if(NOT "${dir}" STREQUAL "${PROJECT_BINARY_DIR}")
+                set(FILES_TO_FORMAT ${FILES_TO_FORMAT} ${infile})
+            endif()
+        endforeach()
 
 
-    foreach(file ${FILES_TO_FORMAT})
-        add_custom_command(TARGET format-${NAME}
-        COMMAND echo Processing ${file}
-        COMMAND ${CLANGFORMAT_PATH} --style=file -i ${file}
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-    endforeach()
+        foreach(file ${FILES_TO_FORMAT})
+            add_custom_command(TARGET format-${NAME}
+            COMMAND echo Processing ${file}
+            COMMAND ${CLANGFORMAT_PATH} --style=file -i ${file}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+        endforeach()
+    endif()
     
     add_dependencies(format format-${NAME})
 

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -1,26 +1,12 @@
-set(CLANGFORMAT_PATH "NOTSET" CACHE STRING "Absolute path to the clang-format executable")
-
-if("${CLANGFORMAT_PATH}" STREQUAL "NOTSET")
-	find_program(FIND_CLANGFORMAT clang-format)
-	if("${FIND_CLANGFORMAT}" STREQUAL "FIND_CLANGFORMAT-NOTFOUND")
-		message(FATAL_ERROR "Could not find 'clang-format' please set CLANGFORMAT_PATH:STRING")
-	else()
-		set(CLANGFORMAT_PATH ${FIND_CLANGFORMAT})
-		message(STATUS "Found: ${CLANGFORMAT_PATH}")
-	endif()
-else()
-	if(NOT EXISTS ${CLANGFORMAT_PATH})
-		message(WARNING "Could not find clang-format: ${CLANGFORMAT_PATH}")
-	else()
-		message(STATUS "Found: ${CLANGFORMAT_PATH}")
-	endif()
-endif()
+find_program(CLANGFORMAT_PATH clang-format)
 
 set(FILES_TO_FORMAT)
 
+add_custom_target(format)
+
 function(Format NAME)
 
-    add_custom_target(Format_${NAME})
+    add_custom_target(format-${NAME})
 
     foreach(infile ${ARGN})
         get_filename_component(dir ${infile} DIRECTORY)
@@ -31,10 +17,12 @@ function(Format NAME)
 
 
     foreach(file ${FILES_TO_FORMAT})
-        add_custom_command(TARGET Format_${NAME}
+        add_custom_command(TARGET format-${NAME}
         COMMAND echo Processing ${file}
         COMMAND ${CLANGFORMAT_PATH} --style=file -i ${file}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     endforeach()
+    
+    add_dependencies(format format-${NAME})
 
 endfunction(Format)

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -1,12 +1,12 @@
 find_program(CLANGFORMAT_PATH clang-format)
 
-set(FILES_TO_FORMAT)
-
 add_custom_target(format)
 
 function(Format NAME)
     if(EXISTS ${CLANGFORMAT_PATH})
         add_custom_target(format-${NAME})
+
+        set(FILES_TO_FORMAT)
 
         foreach(infile ${ARGN})
             get_filename_component(dir ${infile} DIRECTORY)

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -1,0 +1,40 @@
+set(CLANGFORMAT_PATH "NOTSET" CACHE STRING "Absolute path to the clang-format executable")
+
+if("${CLANGFORMAT_PATH}" STREQUAL "NOTSET")
+	find_program(FIND_CLANGFORMAT clang-format)
+	if("${FIND_CLANGFORMAT}" STREQUAL "FIND_CLANGFORMAT-NOTFOUND")
+		message(FATAL_ERROR "Could not find 'clang-format' please set CLANGFORMAT_PATH:STRING")
+	else()
+		set(CLANGFORMAT_PATH ${FIND_CLANGFORMAT})
+		message(STATUS "Found: ${CLANGFORMAT_PATH}")
+	endif()
+else()
+	if(NOT EXISTS ${CLANGFORMAT_PATH})
+		message(WARNING "Could not find clang-format: ${CLANGFORMAT_PATH}")
+	else()
+		message(STATUS "Found: ${CLANGFORMAT_PATH}")
+	endif()
+endif()
+
+set(FILES_TO_FORMAT)
+
+function(Format NAME)
+
+    add_custom_target(Format_${NAME})
+
+    foreach(infile ${ARGN})
+        get_filename_component(dir ${infile} DIRECTORY)
+        if(NOT "${dir}" STREQUAL "${PROJECT_BINARY_DIR}")
+            set(FILES_TO_FORMAT ${FILES_TO_FORMAT} ${infile})
+        endif()
+    endforeach()
+
+
+    foreach(file ${FILES_TO_FORMAT})
+        add_custom_command(TARGET Format_${NAME}
+        COMMAND echo Processing ${file}
+        COMMAND ${CLANGFORMAT_PATH} --style=file -i ${file}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    endforeach()
+
+endfunction(Format)

--- a/logic/CMakeLists.txt
+++ b/logic/CMakeLists.txt
@@ -271,6 +271,9 @@ set(LOGIC_SOURCES
 	tools/MCEditTool.h
 
 )
+
+Format(Logic ${LOGIC_SOURCES})
+
 ################################ COMPILE ################################
 
 # Add common library


### PR DESCRIPTION
Adds a make target that formats all source code using clang-format
Currently separate targets for each component, logic and application