### PR TITLE
Fixed overwriting of wrapper command

### DIFF
--- a/application/pages/InstanceSettingsPage.cpp
+++ b/application/pages/InstanceSettingsPage.cpp
@@ -119,7 +119,7 @@ void InstanceSettingsPage::applySettings()
 	if (custcmd)
 	{
 		m_settings->set("PreLaunchCommand", ui->preLaunchCmdTextBox->text());
-		m_settings->set("WrapperCommand", ui->preLaunchCmdTextBox->text());
+		m_settings->set("WrapperCommand", ui->wrapperCmdTextBox->text());
 		m_settings->set("PostExitCommand", ui->postExitCmdTextBox->text());
 	}
 	else


### PR DESCRIPTION
Fixed "WrapperCommand" setting being overwritten by the value of "PreLaunchCommand".