### PR TITLE
Mod download using a built-in browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ os:
  - linux
 # - osx
 env:
- - QT_VERSION=5.4.1 # latest stable
-# - QT_VERSION=5.5-beta # latest
+ - QT_VERSION=5.5.1 # latest stable
 matrix:
   exclude:
     # only use clang on OS X
@@ -21,13 +20,7 @@ matrix:
       compiler: gcc
     # only use the qt available from homebrew
     - os: osx
-      env: QT_VERSION=5.4.1
-    - os: osx
-      env: QT_VERSION=5.5-beta
-
-  allow_failures:
-    # Qt 5.5 is not yet released and is therefore allowed to fail
-    - env: QT_VERSION=5.5-beta
+      env: QT_VERSION=5.5.1
 
 notifications:
   irc: "irc.esper.net#MultiMC"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ find_package(Qt5Concurrent REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)
 find_package(Qt5Xml REQUIRED)
+find_package(Qt5WebEngineWidgets REQUIRED)
 
 include_directories(
 	${Qt5Core_INCLUDE_DIRS}
@@ -58,6 +59,7 @@ include_directories(
 	${Qt5Test_INCLUDE_DIRS}
 	${Qt5Network_INCLUDE_DIRS}
 	${Qt5Xml_INCLUDE_DIRS}
+	${Qt5WebEngineWidgets_INCLUDE_DIRS}
 )
 
 # The Qt5 cmake files don't provide its install paths, so ask qmake.

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -231,6 +231,8 @@ SET(MULTIMC_SOURCES
 	dialogs/UpdateDialog.h
 	dialogs/VersionSelectDialog.cpp
 	dialogs/VersionSelectDialog.h
+	dialogs/WebDownloadDialog.cpp
+	dialogs/WebDownloadDialog.h
 
 
 	# GUI - widgets
@@ -341,7 +343,7 @@ qt5_add_resources(MULTIMC_RESOURCES ${MULTIMC_QRCS})
 # Add executable
 add_executable(MultiMC MACOSX_BUNDLE WIN32 ${MULTIMC_SOURCES} ${MULTIMC_UI} ${MULTIMC_RESOURCES} ${MULTIMC_RCS})
 target_link_libraries(MultiMC MultiMC_logic xz-embedded unpack200 iconfix libUtil LogicalGui
-	${QUAZIP_LIBRARIES} Qt5::Core Qt5::Xml Qt5::Widgets Qt5::Network Qt5::Concurrent
+	${QUAZIP_LIBRARIES} Qt5::Core Qt5::Xml Qt5::Widgets Qt5::Network Qt5::Concurrent Qt5::WebEngineWidgets
 		hoedown rainbow
 			${MultiMC_LINK_ADDITIONAL_LIBS})
 

--- a/application/dialogs/WebDownloadDialog.cpp
+++ b/application/dialogs/WebDownloadDialog.cpp
@@ -1,0 +1,132 @@
+#include "WebDownloadDialog.h"
+
+#include <QWebEngineView>
+#include <QWebEnginePage>
+#include <QWebEngineProfile>
+#include <QWebEngineDownloadItem>
+
+#include <QGridLayout>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QLabel>
+#include <QAction>
+#include <QProgressBar>
+#include <QDebug>
+
+#include "tasks/Task.h"
+#include "widgets/ProgressWidget.h"
+
+class WebEngineDownloadTask : public Task
+{
+public:
+	explicit WebEngineDownloadTask(QWebEngineDownloadItem *dl, QObject *parent = nullptr)
+		: Task(parent), m_dl(dl)
+	{
+		connect(m_dl, &QWebEngineDownloadItem::downloadProgress, this, &WebEngineDownloadTask::setProgress);
+		connect(m_dl, &QWebEngineDownloadItem::stateChanged, this, &WebEngineDownloadTask::stateChanged);
+	}
+
+	bool canAbort() const override { return true; }
+	bool abort() override
+	{
+		m_dl->cancel();
+		return true;
+	}
+	void executeTask() override
+	{
+		setStatus(tr("Downloading %1...").arg(m_dl->url().toString()));
+	}
+
+	void stateChanged(const QWebEngineDownloadItem::DownloadState state)
+	{
+		switch (state) {
+		case QWebEngineDownloadItem::DownloadCancelled:
+			emitFailed(tr("The download was cancelled by the user"));
+			break;
+		case QWebEngineDownloadItem::DownloadInterrupted:
+			emitFailed(tr("The download was interrupted"));
+			break;
+		case QWebEngineDownloadItem::DownloadCompleted:
+			emitSucceeded();
+			break;
+		default: break;
+		}
+	}
+
+	QWebEngineDownloadItem *m_dl;
+};
+
+WebDownloadDialog::WebDownloadDialog(const QUrl &url, const QDir &dir, QWidget *parent)
+	: QDialog(parent), m_dir(dir)
+{
+	m_webview = new QWebEngineView(this);
+
+	auto createButtonFromAction = [](QAction *action, QWidget *parent)
+	{
+		QPushButton *btn = new QPushButton(parent);
+		btn->setIcon(action->icon());
+		btn->setToolTip(action->toolTip());
+		btn->setWhatsThis(action->whatsThis());
+		btn->setCheckable(action->isCheckable());
+		btn->setChecked(action->isChecked());
+		WebDownloadDialog::connect(btn, &QPushButton::clicked, action, &QAction::trigger);
+		WebDownloadDialog::connect(action, &QAction::triggered, btn, &QPushButton::setChecked);
+		return btn;
+	};
+
+	QGridLayout *layout = new QGridLayout(this);
+	layout->addWidget(m_backBtn = createButtonFromAction(m_webview->pageAction(QWebEnginePage::Back), this), 0, 0);
+	layout->addWidget(m_forwardBtn = createButtonFromAction(m_webview->pageAction(QWebEnginePage::Forward), this), 0, 1);
+	layout->addWidget(m_reloadBtn = createButtonFromAction(m_webview->pageAction(QWebEnginePage::Reload), this), 0, 2);
+
+	QLineEdit *urlEdit = new QLineEdit(this);
+	urlEdit->setReadOnly(true);
+	urlEdit->setEnabled(false);
+	urlEdit->setText(m_webview->url().toString());
+	connect(m_webview, &QWebEngineView::urlChanged, urlEdit, [urlEdit](const QUrl &url) { urlEdit->setText(url.toString()); });
+	layout->addWidget(urlEdit, 0, 3);
+
+	QProgressBar *progressBar = new QProgressBar(this);
+	progressBar->setMinimum(0);
+	progressBar->setMaximum(100);
+	connect(m_webview, &QWebEngineView::loadStarted, progressBar, &QProgressBar::show);
+	connect(m_webview, &QWebEngineView::loadFinished, progressBar, &QProgressBar::hide);
+	connect(m_webview, &QWebEngineView::loadProgress, progressBar, &QProgressBar::setValue);
+	layout->addWidget(progressBar, 0, 4);
+
+	layout->addWidget(m_webview, 1, 0, 1, 5);
+
+	m_progress = new ProgressWidget(this);
+	m_progress->hide();
+	layout->addWidget(m_progress, 2, 0, 1, 5);
+
+	connect(m_webview->page()->profile(), &QWebEngineProfile::downloadRequested, this, &WebDownloadDialog::downloadRequested);
+
+	m_webview->load(url);
+}
+
+void WebDownloadDialog::runNonModal(const QUrl &url, const QDir &dir, QWidget *parent)
+{
+	WebDownloadDialog dlg(url, dir, parent);
+	connect(&dlg, &WebDownloadDialog::completed, &dlg, &WebDownloadDialog::accept);
+	dlg.exec();
+}
+
+void WebDownloadDialog::downloadRequested(QWebEngineDownloadItem *dl)
+{
+	m_backBtn->setEnabled(false);
+	m_forwardBtn->setEnabled(false);
+	m_reloadBtn->setEnabled(false);
+	m_webview->setEnabled(false);
+	m_progress->show();
+
+	dl->setPath(m_dir.absoluteFilePath(QFileInfo(dl->url().path()).fileName()));
+	qDebug() << "Caught download for" << dl->url().toString() << ", it will be downloaded to" << dl->path();
+
+	m_task = std::make_shared<WebEngineDownloadTask>(dl, this);
+	emit starting(m_task);
+	connect(m_task.get(), &Task::finished, this, &WebDownloadDialog::completed);
+	m_progress->start(m_task);
+
+	dl->accept();
+}

--- a/application/dialogs/WebDownloadDialog.h
+++ b/application/dialogs/WebDownloadDialog.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QDialog>
+#include <QDir>
+#include <memory>
+
+class QWebEngineView;
+class QWebEngineDownloadItem;
+class QPushButton;
+class Task;
+class ProgressWidget;
+
+class WebDownloadDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	explicit WebDownloadDialog(const QUrl &url, const QDir &dir, QWidget *parent = nullptr);
+
+	static void runNonModal(const QUrl &url, const QDir &dir, QWidget *parent = nullptr);
+
+private slots:
+	void downloadRequested(QWebEngineDownloadItem *dl);
+
+signals:
+	void starting(const std::shared_ptr<Task> &task);
+	void completed();
+
+private:
+	QWebEngineView *m_webview;
+	QPushButton *m_backBtn;
+	QPushButton *m_forwardBtn;
+	QPushButton *m_reloadBtn;
+	ProgressWidget *m_progress;
+
+	QDir m_dir;
+	std::shared_ptr<Task> m_task;
+};

--- a/application/pages/ModFolderPage.cpp
+++ b/application/pages/ModFolderPage.cpp
@@ -27,7 +27,9 @@
 #include "MultiMC.h"
 #include "dialogs/CustomMessageBox.h"
 #include "dialogs/ModEditDialogCommon.h"
-#include <GuiUtil.h>
+#include "dialogs/WebDownloadDialog.h"
+#include "GuiUtil.h"
+
 #include "minecraft/ModList.h"
 #include "minecraft/Mod.h"
 #include "minecraft/VersionFilterData.h"
@@ -49,8 +51,8 @@ ModFolderPage::ModFolderPage(BaseInstance *inst, std::shared_ptr<ModList> mods, 
 	ui->modTreeView->setModel(m_mods.get());
 	ui->modTreeView->installEventFilter(this);
 	auto smodel = ui->modTreeView->selectionModel();
-	connect(smodel, SIGNAL(currentChanged(QModelIndex, QModelIndex)),
-			SLOT(modCurrent(QModelIndex, QModelIndex)));
+	connect(smodel, &QItemSelectionModel::currentChanged, this, &ModFolderPage::modCurrent);
+	connect(m_mods.get(), &ModList::remoteUrlDropped, this, &ModFolderPage::remoteDownloadRequest);
 }
 
 void ModFolderPage::opened()
@@ -164,6 +166,11 @@ void ModFolderPage::on_rmModBtn_clicked()
 void ModFolderPage::on_viewModBtn_clicked()
 {
 	openDirInDefaultProgram(m_mods->dir().absolutePath(), true);
+}
+
+void ModFolderPage::remoteDownloadRequest(const QUrl &url)
+{
+	WebDownloadDialog::runNonModal(url, m_mods->dir(), this);
 }
 
 void ModFolderPage::modCurrent(const QModelIndex &current, const QModelIndex &previous)

--- a/application/pages/ModFolderPage.h
+++ b/application/pages/ModFolderPage.h
@@ -87,6 +87,8 @@ slots:
 	void on_addModBtn_clicked();
 	void on_rmModBtn_clicked();
 	void on_viewModBtn_clicked();
+
+	void remoteDownloadRequest(const QUrl &url);
 };
 
 class CoreModFolderPage : public ModFolderPage

--- a/logic/minecraft/ModList.h
+++ b/logic/minecraft/ModList.h
@@ -149,6 +149,7 @@ slots:
 
 signals:
 	void changed();
+	void remoteUrlDropped(const QUrl &url);
 
 protected:
 	QFileSystemWatcher *m_watcher;

--- a/travis/prepare.sh
+++ b/travis/prepare.sh
@@ -2,23 +2,25 @@ set -e
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]
 then
-	QT_WITHOUT_DOTS=qt$(echo $QT_VERSION | grep -oP "[^\.]*" | tr -d '\n' | tr '[:upper:]' '[:lower]')
+	QT_WITHOUT_DOTS=$(echo $QT_VERSION | grep -oP "[^\.]*" | tr -d '\n' | tr '[:upper:]' '[:lower]')
 	QT_PKG_PREFIX=$(echo $QT_WITHOUT_DOTS | cut -c1-4)
 	echo $QT_WITHOUT_DOTS
 	echo $QT_PKG_PREFIX
-	sudo add-apt-repository -y ppa:beineri/opt-${QT_WITHOUT_DOTS}
+	#sudo add-apt-repository -y ppa:beineri/opt-${QT_WITHOUT_DOTS}
+	wget http://static.02jandal.xyz/qt${QT_WITHOUT_DOTS}-precise_${QT_VERSION}-1_amd64.deb
 	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test # for a recent GCC
-	sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main"
+	sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main"
 
 	sudo apt-get update -qq
-	sudo apt-get install ${QT_PKG_PREFIX}base ${QT_PKG_PREFIX}svg ${QT_PKG_PREFIX}tools ${QT_PKG_PREFIX}x11extras ${QT_PKG_PREFIX}webkit
+	#sudo apt-get install ${QT_PKG_PREFIX}base ${QT_PKG_PREFIX}svg ${QT_PKG_PREFIX}tools ${QT_PKG_PREFIX}x11extras ${QT_PKG_PREFIX}webengine
+	sudo dpkg -i qt${QT_WITHOUT_DOTS}-precise_${QT_VERSION}-1_amd64.deb
 
 	sudo mkdir -p /opt/cmake-3/
 	wget http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.sh
 	sudo sh cmake-3.2.2-Linux-x86_64.sh --skip-license --prefix=/opt/cmake-3/
 
-	export CMAKE_PREFIX_PATH=/opt/$QT_PKG_PREFIX/lib/cmake
-	export PATH=/opt/cmake-3/bin:/opt/$QT_PKG_PREFIX/bin:$PATH
+	export CMAKE_PREFIX_PATH=/usr/local/Qt-${QT_VERSION}/lib/cmake
+	export PATH=/opt/cmake-3/bin:/usr/local/Qt-${QT_VERSION}/bin:$PATH
 
 	if [ "$CXX" = "g++" ]; then
 		sudo apt-get install -y -qq g++-5
@@ -26,8 +28,8 @@ then
 	fi
 	if [ "$CXX" = "clang++" ]; then
 		wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
-		sudo apt-get install -y -qq clang-3.5 liblldb-3.5 libclang1-3.5 libllvm3.5 lldb-3.5 llvm-3.5 llvm-3.5-runtime
-		export CXX='clang++-3.5' CC='clang-3.5'
+		sudo apt-get install -y -qq clang-3.7 liblldb-3.7 libclang1-3.7 libllvm3.7 lldb-3.7 llvm-3.7 llvm-3.7-runtime
+		export CXX='clang++-3.7' CC='clang-3.7'
 	fi
 else
 	brew update


### PR DESCRIPTION
When a URL is dropped on any ModFolderPage (mods, coremods, texturepacks, resourcepacks) a built-in browser is opened, allowing the user to navigate through adfly etc. Once the actual download starts it will automatically be put in the correct place.