### PR TITLE
Make translations respect data path, on Linux.

### DIFF
--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -172,8 +172,7 @@ MultiMC::MultiMC(int &argc, char **argv, bool test_mode) : QApplication(argc, ar
 
 // static data paths... mostly just for translations
 #ifdef Q_OS_LINUX
-	QDir foo(FS::PathCombine(binPath, ".."));
-	staticDataPath = foo.absolutePath();
+	staticDataPath = dataPath;
 #elif defined(Q_OS_WIN32)
 	staticDataPath = binPath;
 #elif defined(Q_OS_MAC)


### PR DESCRIPTION
This allows the path where translations are installed to also be controlled by the -d argument. There is probably a better way to handle this, but it isn't good form to require write access to the directory above a binary on Linux. This also just makes MultiMC confine its files to one directory. Which is very useful if you launch it with the -d ~/.multimc option.