### PR TITLE
Add more qt versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,34 @@ os:
  - linux
 # - osx
 env:
- - QT_VERSION=5.5.1 # latest stable
-# - QT_VERSION=5.5-beta # latest
+ - QT_VERSION=5.0.2
+ - QT_VERSION=5.1.1
+ - QT_VERSION=5.2.1
+ - QT_VERSION=5.3.2
+ - QT_VERSION=5.4.2
+ - QT_VERSION=5.5.1 # latest
 matrix:
   exclude:
     # only use clang on OS X
     - os: osx
       compiler: gcc
+    # only use the qt available from homebrew
+    - os: osx
+      env: QT_VERSION=5.0.2
+    - os: osx
+      env: QT_VERSION=5.1.1
+    - os: osx
+      env: QT_VERSION=5.2.1
+    - os: osx
+      env: QT_VERSION=5.3.2
+    - os: osx
+      env: QT_VERSION=5.4.2
+    - os: osx
+      env: QT_VERSION=5.5.1
+  allow_failures:
+    - env: QT_VERSION=5.0.2
+    - env: QT_VERSION=5.1.1
+    - env: QT_VERSION=5.2.1
 
 # Install dependencies
 install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,12 @@ include(Coverity)
 ################################ 3rd Party Libs ################################
 
 # Find the required Qt parts
-find_package(Qt5 COMPONENTS Core Widgets Concurrent Network Test Xml)
+find_package(Qt5Core)
+find_package(Qt5Widgets)
+find_package(Qt5Concurrent)
+find_package(Qt5Network)
+find_package(Qt5Test)
+find_package(Qt5Xml)
 
 # The Qt5 cmake files don't provide its install paths, so ask qmake.
 include(QMakeQuery)

--- a/logic/Exception.h
+++ b/logic/Exception.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <QString>
-#include <QLoggingCategory>
+#include <QDebug>
 #include <exception>
 
 #include "multimc_logic_export.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # run the unit tests with `make test`
-find_package(Qt5 COMPONENTS Test Core Network)
+find_package(Qt5Test)
 
 unset(MultiMC_TESTS)
 macro(add_unit_test name)

--- a/tests/tst_FileSystem.cpp
+++ b/tests/tst_FileSystem.cpp
@@ -1,4 +1,5 @@
 #include <QTest>
+#include <QTemporaryDir>
 #include "TestUtil.h"
 
 #include "FileSystem.h"

--- a/tests/tst_ModList.cpp
+++ b/tests/tst_ModList.cpp
@@ -1,5 +1,6 @@
 
 #include <QTest>
+#include <QTemporaryDir>
 #include "TestUtil.h"
 
 #include "FileSystem.h"

--- a/travis/prepare.sh
+++ b/travis/prepare.sh
@@ -4,21 +4,24 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]
 then
 	QT_WITHOUT_DOTS=qt$(echo $QT_VERSION | grep -oP "[^\.]*" | tr -d '\n' | tr '[:upper:]' '[:lower]')
 	QT_PKG_PREFIX=$(echo $QT_WITHOUT_DOTS | cut -c1-4)
+	QT_PKG_INSTALL=$QT_PKG_PREFIX
+	if [ "$QT_PKG_PREFIX" = "qt50" ]; then QT_PKG_PREFIX=qt QT_PKG_INSTALL=qt5; fi
 	echo $QT_WITHOUT_DOTS
 	echo $QT_PKG_PREFIX
+	echo $QT_PKG_INSTALL
 	sudo add-apt-repository -y ppa:beineri/opt-${QT_WITHOUT_DOTS}
 	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test # for a recent GCC
 	sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main"
 
 	sudo apt-get update -qq
-	sudo apt-get install ${QT_PKG_PREFIX}base ${QT_PKG_PREFIX}svg ${QT_PKG_PREFIX}tools ${QT_PKG_PREFIX}x11extras ${QT_PKG_PREFIX}webkit
+	sudo apt-get install ${QT_PKG_PREFIX}base ${QT_PKG_PREFIX}svg ${QT_PKG_PREFIX}tools ${QT_PKG_PREFIX}webkit
 
 	sudo mkdir -p /opt/cmake-3/
 	wget --no-check-certificate http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.sh
 	sudo sh cmake-3.2.2-Linux-x86_64.sh --skip-license --prefix=/opt/cmake-3/
 
-	export CMAKE_PREFIX_PATH=/opt/$QT_PKG_PREFIX/lib/cmake
-	export PATH=/opt/cmake-3/bin:/opt/$QT_PKG_PREFIX/bin:$PATH
+	export CMAKE_PREFIX_PATH=/opt/$QT_PKG_INSTALL/lib/cmake
+	export PATH=/opt/cmake-3/bin:/opt/$QT_PKG_INSTALL/bin:$PATH
 
 	if [ "$CXX" = "g++" ]; then
 		sudo apt-get install -y -qq g++-5
@@ -40,3 +43,4 @@ fi
 cmake -version
 qmake -version
 $CXX -v
+echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH"


### PR DESCRIPTION
5.0, 5.1 and 5.2 are currently marked as "allow failure". If they can be made
to pass they should be removed from this list, if not they should be removed
entirely.

The change in the find_package signature is required for Qt 5.0, which doesn't support the COMPONENTS style find_package call.