### PR TITLE
Do not ask to overwrite existing file twice.

### DIFF
--- a/application/dialogs/ExportInstanceDialog.cpp
+++ b/application/dialogs/ExportInstanceDialog.cpp
@@ -386,7 +386,7 @@ bool ExportInstanceDialog::doExport()
 
 	const QString output = QFileDialog::getSaveFileName(
 		this, tr("Export %1").arg(m_instance->name()),
-		FS::PathCombine(QDir::homePath(), name + ".zip"), "Zip (*.zip)");
+		FS::PathCombine(QDir::homePath(), name + ".zip"), "Zip (*.zip)", nullptr, QFileDialog::DontConfirmOverwrite);
 	if (output.isNull())
 	{
 		return false;


### PR DESCRIPTION
When exporting an instance to an existing file, the user is asked to confirm overwrite twice:
first by QFileDialog, then by the app itself.