### PR TITLE
Remove unnecessary translation strings

### DIFF
--- a/application/InstancePageProvider.h
+++ b/application/InstancePageProvider.h
@@ -34,7 +34,7 @@ public:
 		{
 			values.append(new VersionPage(onesix.get()));
 			auto modsPage = new ModFolderPage(onesix.get(), onesix->loaderModList(), "mods", "loadermods", tr("Loader mods"), "Loader-mods");
-			modsPage->setFilter(tr("%1 (*.zip *.jar *.litemod)"));
+			modsPage->setFilter("%1 (*.zip *.jar *.litemod)");
 			values.append(modsPage);
 			values.append(new CoreModFolderPage(onesix.get(), onesix->coreModList(), "coremods", "coremods", tr("Core mods"), "Core-mods"));
 			values.append(new ResourcePackPage(onesix.get()));
@@ -51,7 +51,7 @@ public:
 			//values.append(new LegacyUpgradePage(this));
 			values.append(new LegacyJarModPage(legacy.get()));
 			auto modsPage = new ModFolderPage(legacy.get(), legacy->loaderModList(), "mods", "loadermods", tr("Loader mods"), "Loader-mods");
-			modsPage->setFilter(tr("%1 (*.zip *.jar *.litemod)"));
+			modsPage->setFilter("%1 (*.zip *.jar *.litemod)");
 			values.append(modsPage);
 			values.append(new ModFolderPage(legacy.get(), legacy->coreModList(), "coremods", "coremods", tr("Core mods"), "Loader-mods"));
 			values.append(new TexturePackPage(legacy.get()));

--- a/application/JavaCommon.cpp
+++ b/application/JavaCommon.cpp
@@ -43,7 +43,7 @@ void JavaCommon::TestCheck::javaArgsWereBad(JavaCheckResult result)
 	QString text;
 	htmlError.replace('\n', "<br />");
 	text += tr("The specified java binary didn't work with the arguments you provided:<br />");
-	text += tr("<font color=\"red\">%1</font>").arg(htmlError);
+	text += QString("<font color=\"red\">%1</font>").arg(htmlError);
 	CustomMessageBox::selectable(m_parent, tr("Java test failure"), text, QMessageBox::Warning)
 		->show();
 }

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -295,7 +295,7 @@ public:
 
 	void retranslateUi(QMainWindow *MainWindow)
 	{
-		MainWindow->setWindowTitle(QApplication::translate("MainWindow", "MultiMC 5", 0));
+		MainWindow->setWindowTitle("MultiMC 5");
 		actionAddInstance->setText(QApplication::translate("MainWindow", "Add Instance", 0));
 		actionAddInstance->setToolTip(QApplication::translate("MainWindow", "Add a new instance.", 0));
 		actionAddInstance->setStatusTip(QApplication::translate("MainWindow", "Add a new instance.", 0));
@@ -638,7 +638,7 @@ void MainWindow::showInstanceContextMenu(const QPoint &pos)
 	}
 	else
 	{
-		QAction *actionVoid = new QAction(tr("MultiMC"), this);
+		QAction *actionVoid = new QAction("MultiMC", this);
 		actionVoid->setEnabled(false);
 
 		QAction *actionCreateInstance = new QAction(tr("Create instance"), this);

--- a/application/dialogs/AboutDialog.ui
+++ b/application/dialogs/AboutDialog.ui
@@ -180,7 +180,7 @@
           </font>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://github.com/MultiMC/MultiMC5&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://github.com/MultiMC/MultiMC5&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://github.com/MultiMC/MultiMC5&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://github.com/MultiMC/MultiMC5&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>

--- a/application/pages/ModFolderPage.cpp
+++ b/application/pages/ModFolderPage.cpp
@@ -43,7 +43,7 @@ ModFolderPage::ModFolderPage(BaseInstance *inst, std::shared_ptr<ModList> mods, 
 	m_displayName = displayName;
 	m_iconName = iconName;
 	m_helpName = helpPage;
-	m_filter = tr("%1 (*.zip *.jar)");
+	m_filter = "%1 (*.zip *.jar)";
 	ui->modTreeView->setModel(m_mods.get());
 	ui->modTreeView->installEventFilter(this);
 	auto smodel = ui->modTreeView->selectionModel();

--- a/application/pages/global/ExternalToolsPage.ui
+++ b/application/pages/global/ExternalToolsPage.ui
@@ -63,7 +63,7 @@
           <item>
            <widget class="QLabel" name="jprofilerLink">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.ej-technologies.com/products/jprofiler/overview.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://www.ej-technologies.com/products/jprofiler/overview.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.ej-technologies.com/products/jprofiler/overview.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://www.ej-technologies.com/products/jprofiler/overview.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -100,7 +100,7 @@
           <item>
            <widget class="QLabel" name="jvisualvmLink">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://visualvm.java.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://visualvm.java.net/&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://visualvm.java.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://visualvm.java.net/&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -137,7 +137,7 @@
           <item>
            <widget class="QLabel" name="mceditLink">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.mcedit.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://www.mcedit.net/&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.mcedit.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://www.mcedit.net/&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>

--- a/application/pages/global/MultiMCPage.h
+++ b/application/pages/global/MultiMCPage.h
@@ -41,7 +41,7 @@ public:
 
 	QString displayName() const override
 	{
-		return tr("MultiMC");
+		return "MultiMC";
 	}
 	QIcon icon() const override
 	{


### PR DESCRIPTION
This PR removes some unnecessary translation strings, from code and UI.
I might have missed some, because I used Weblates "Source and Translation are equal" error list.

EDIT: Found more strings, will update with more commits...