### PR TITLE
Point people to the wiki for attaching logs to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -41,6 +41,7 @@ Suspected cause:
 
 Logs/Screenshots:
 ----------------------------
+[//]: # (Please refer to https://github.com/MultiMC/MultiMC5/wiki/Log-Upload for instructions on how to attach your logs.)
 
 
 Additional Info:


### PR DESCRIPTION
A lot of people miss this and you just end up with a bunch of clutter in the actual issue, often hard or impossible to read because of the lack of backticks.