### PR TITLE
Add missing <functional> include.

### DIFF
--- a/api/logic/QObjectPtr.h
+++ b/api/logic/QObjectPtr.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <QObject>
 


### PR DESCRIPTION
Compiling under Linux fails because of a missing include directive
Ref:
http://en.cppreference.com/w/cpp/utility/functional/bind
http://en.cppreference.com/w/cpp/utility/functional/placeholders