### PR TITLE
Mention casing in ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,8 +9,9 @@ Before submitting this issue, please make sure you have:
 	- We provide support for MultiMC, not your modpack. Problems with your modpack will be ignored.
  4. Given the issue a descriptive title.
 	- A good title includes a brief summary of the issue and avoids things such as "Help" and "What?!".
+	  Use of UPPERCASE is discouraged, as it reads like someone is screaming.
  5. Place all information below the ---- of lines.
- - It makes the issue look pretty
+ 	- It makes the issue look pretty
  
 If you believe your issue to be a bug, please make sure you check the wiki page: https://github.com/MultiMC/MultiMC5/wiki/Report-a-Bug
 -->


### PR DESCRIPTION
I found it distracting when reading through the issues list, and assume I'm not alone in that regard. It's easy to forget if this is you first time you're writing an issue, so a small reminder should be good.

_(I also fix an indentation, as you can see.)_