### PR TITLE
GH-2103 Make /usr/local the default prefix for lin-system

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -393,10 +393,6 @@ elseif(MultiMC_LAYOUT_REAL STREQUAL "lin-nodeps")
 	install(PROGRAMS package/linux/MultiMC DESTINATION ${BUNDLE_DEST_DIR})
 
 elseif(MultiMC_LAYOUT_REAL STREQUAL "lin-system")
-	if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-		SET(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Base directory for executables and libraries" FORCE)
-	endif()
-
 	set(MultiMC_BINARY_DEST_DIR "bin" CACHE STRING "Path to the binary directory")
 	set(MultiMC_LIBRARY_DEST_DIR "lib${LIB_SUFFIX}" CACHE STRING "Path to the library directory")
 	set(MultiMC_SHARE_DEST_DIR "share/multimc" CACHE STRING "Path to the shared data directory")


### PR DESCRIPTION
/usr/local is a sane default since /usr is meant to be used by packages.

Better to fix it now since we are already redesigning then later. Users would have to adjust their variables anyway.