### PR TITLE
Fix MultiMC spelling in .desktop file

### DIFF
--- a/application/package/linux/multimc.desktop
+++ b/application/package/linux/multimc.desktop
@@ -5,6 +5,6 @@ GenericName=MultiMC
 Comment=Free, open source launcher and instance manager for Minecraft.
 Type=Application
 Terminal=false
-Exec=multimc
+Exec=MultiMC
 Icon=multimc
 Categories=Game


### PR DESCRIPTION
At some point, the multimc binary was renamed from `multimc` to `MultiMC`, causing the .desktop file to break and not show up in the system applications menu. 