### PR TITLE
add "minecraft" keyword to .desktop entries

### DIFF
--- a/application/package/linux/multimc.desktop
+++ b/application/package/linux/multimc.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Exec=multimc
 Icon=multimc
 Categories=Game
+Keywords=game;minecraft;

--- a/application/package/ubuntu/multimc/usr/share/applications/multimc.desktop
+++ b/application/package/ubuntu/multimc/usr/share/applications/multimc.desktop
@@ -2,7 +2,7 @@
 Categories=Game;
 Exec=/opt/multimc/run.sh
 Icon=/opt/multimc/icon.svg
-Keywords=game;
+Keywords=game;Minecraft;
 MimeType=
 Name=MultiMC 5
 Path=


### PR DESCRIPTION
This is pretty much just a QoL change that lets you search "minecraft" and have multiMC also pop up in search menus. I also added the `Keywords` key to the .desktop entry in the Linux portion, its considered a standard key so it shouldn't cause any issues from DE to DE.