### PR TITLE
GH-2487 Make deleting instances harder

### DIFF
--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -1634,7 +1634,8 @@ void MainWindow::on_actionDeleteInstance_triggered()
         tr("CAREFUL!"),
         tr("About to delete: %1\nThis is permanent and will completely delete the instance.\n\nAre you sure?").arg(m_selectedInstance->name()),
         QMessageBox::Warning,
-        QMessageBox::Yes | QMessageBox::No
+        QMessageBox::Yes | QMessageBox::No,
+        QMessageBox::No
     )->exec();
     if (response == QMessageBox::Yes)
     {


### PR DESCRIPTION
Currently makes no the default option in the confirmation dialogue for instance deletion.