### PR TITLE
Support launching profiler in offline mode

### DIFF
--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -934,7 +934,7 @@ void MainWindow::updateToolsMenu()
     }
 
     QAction *normalLaunch = launchMenu->addAction(tr("Launch"));
-    QAction *normalLaunchOffline = launchOfflineMenu->addAction(tr("Launch"));
+    QAction *normalLaunchOffline = launchOfflineMenu->addAction(tr("Launch Offline"));
     connect(normalLaunch, &QAction::triggered, [this]()
             {
                 MMC->launch(m_selectedInstance, true);
@@ -943,8 +943,9 @@ void MainWindow::updateToolsMenu()
             {
                 MMC->launch(m_selectedInstance, false);
             });
-    launchMenu->addSeparator()->setText(tr("Profilers"));
-    launchOfflineMenu->addSeparator()->setText(tr("Profilers"));
+    QString profilersTitle = tr("Profilers");
+    launchMenu->addSeparator()->setText(profilersTitle);
+    launchOfflineMenu->addSeparator()->setText(profilersTitle);
     for (auto profiler : MMC->profilers().values())
     {
         QAction *profilerAction = launchMenu->addAction(profiler->name());
@@ -954,8 +955,9 @@ void MainWindow::updateToolsMenu()
         {
             profilerAction->setDisabled(true);
             profilerOfflineAction->setDisabled(true);
-            profilerAction->setToolTip(tr("Profiler not setup correctly. Go into settings, \"External Tools\"."));
-            profilerOfflineAction->setToolTip(tr("Profiler not setup correctly. Go into settings, \"External Tools\"."));
+            QString profilerToolTip = tr("Profiler not setup correctly. Go into settings, \"External Tools\".");
+            profilerAction->setToolTip(profilerToolTip);
+            profilerOfflineAction->setToolTip(profilerToolTip);
         }
         else
         {

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -902,7 +902,7 @@ void MainWindow::showInstanceContextMenu(const QPoint &pos)
 void MainWindow::updateToolsMenu()
 {
     QToolButton *launchButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstance));
-    QToolButton* launchOfflineButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstanceOffline));
+    QToolButton *launchOfflineButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstanceOffline));
 
     if(!m_selectedInstance || m_selectedInstance->isRunning())
     {
@@ -914,7 +914,7 @@ void MainWindow::updateToolsMenu()
     }
 
     QMenu *launchMenu = ui->actionLaunchInstance->menu();
-    QMenu* launchOfflineMenu = ui->actionLaunchInstanceOffline->menu();
+    QMenu *launchOfflineMenu = ui->actionLaunchInstanceOffline->menu();
     launchButton->setPopupMode(QToolButton::MenuButtonPopup);
     launchOfflineButton->setPopupMode(QToolButton::MenuButtonPopup);
     if (launchMenu)
@@ -934,7 +934,7 @@ void MainWindow::updateToolsMenu()
     }
 
     QAction *normalLaunch = launchMenu->addAction(tr("Launch"));
-    QAction* normalLaunchOffline = launchOfflineMenu->addAction(tr("Launch"));
+    QAction *normalLaunchOffline = launchOfflineMenu->addAction(tr("Launch"));
     connect(normalLaunch, &QAction::triggered, [this]()
             {
                 MMC->launch(m_selectedInstance, true);
@@ -948,7 +948,7 @@ void MainWindow::updateToolsMenu()
     for (auto profiler : MMC->profilers().values())
     {
         QAction *profilerAction = launchMenu->addAction(profiler->name());
-        QAction* profilerOfflineAction = launchOfflineMenu->addAction(profiler->name());
+        QAction *profilerOfflineAction = launchOfflineMenu->addAction(profiler->name());
         QString error;
         if (!profiler->check(&error))
         {

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -902,15 +902,21 @@ void MainWindow::showInstanceContextMenu(const QPoint &pos)
 void MainWindow::updateToolsMenu()
 {
     QToolButton *launchButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstance));
+    QToolButton* launchOfflineButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstanceOffline));
+
     if(!m_selectedInstance || m_selectedInstance->isRunning())
     {
         ui->actionLaunchInstance->setMenu(nullptr);
+        ui->actionLaunchInstanceOffline->setMenu(nullptr);
         launchButton->setPopupMode(QToolButton::InstantPopup);
+        launchOfflineButton->setPopupMode(QToolButton::InstantPopup);
         return;
     }
 
     QMenu *launchMenu = ui->actionLaunchInstance->menu();
+    QMenu* launchOfflineMenu = ui->actionLaunchInstanceOffline->menu();
     launchButton->setPopupMode(QToolButton::MenuButtonPopup);
+    launchOfflineButton->setPopupMode(QToolButton::MenuButtonPopup);
     if (launchMenu)
     {
         launchMenu->clear();
@@ -919,21 +925,37 @@ void MainWindow::updateToolsMenu()
     {
         launchMenu = new QMenu(this);
     }
+    if (launchOfflineMenu) {
+        launchOfflineMenu->clear();
+    }
+    else
+    {
+        launchOfflineMenu = new QMenu(this);
+    }
 
     QAction *normalLaunch = launchMenu->addAction(tr("Launch"));
+    QAction* normalLaunchOffline = launchOfflineMenu->addAction(tr("Launch"));
     connect(normalLaunch, &QAction::triggered, [this]()
             {
-                MMC->launch(m_selectedInstance);
+                MMC->launch(m_selectedInstance, true);
+            });
+    connect(normalLaunchOffline, &QAction::triggered, [this]()
+            {
+                MMC->launch(m_selectedInstance, false);
             });
     launchMenu->addSeparator()->setText(tr("Profilers"));
+    launchOfflineMenu->addSeparator()->setText(tr("Profilers"));
     for (auto profiler : MMC->profilers().values())
     {
         QAction *profilerAction = launchMenu->addAction(profiler->name());
+        QAction* profilerOfflineAction = launchOfflineMenu->addAction(profiler->name());
         QString error;
         if (!profiler->check(&error))
         {
             profilerAction->setDisabled(true);
+            profilerOfflineAction->setDisabled(true);
             profilerAction->setToolTip(tr("Profiler not setup correctly. Go into settings, \"External Tools\"."));
+            profilerOfflineAction->setToolTip(tr("Profiler not setup correctly. Go into settings, \"External Tools\"."));
         }
         else
         {
@@ -941,9 +963,14 @@ void MainWindow::updateToolsMenu()
                     {
                         MMC->launch(m_selectedInstance, true, profiler.get());
                     });
+            connect(profilerOfflineAction, &QAction::triggered, [this, profiler]()
+                    {
+                        MMC->launch(m_selectedInstance, false, profiler.get());
+                    });
         }
     }
     ui->actionLaunchInstance->setMenu(launchMenu);
+    ui->actionLaunchInstanceOffline->setMenu(launchOfflineMenu);
 }
 
 QString profileInUseFilter(const QString & profile, bool used)


### PR DESCRIPTION
This PR adds the necessary GUI controls to let the user choose
whether they want to launch Minecraft in offline mode with a configured profiler. It works similarly to the already existing feature for online mode.