### PR TITLE
Adjust instance importing so that it can use a hybrid approach.

### DIFF
--- a/api/logic/InstanceImportTask.h
+++ b/api/logic/InstanceImportTask.h
@@ -27,8 +27,8 @@ protected:
 
 private:
     void processZipPack();
-    void processMultiMC();
-    void processFlame();
+    void processMultiMC(bool hybrid);
+    void processFlame(bool hybrid);
 
 private slots:
     void downloadSucceeded();
@@ -49,6 +49,7 @@ private: /* data */
     enum class ModpackType{
         Unknown,
         MultiMC,
-        Flame
+        Flame,
+        Hybrid
     } m_modpackType = ModpackType::Unknown;
 };


### PR DESCRIPTION
Start with a MultiMC instance and add Flame mods to it. This will allow using
Fabric mod loader MultiMC instance generation (https://fabricmc.net/use/) with Flame manifest.json and overrides.

If both types are found, it will use the root of MultiMC for both. If roots should be found separately I can add that capability.