### PR TITLE
Pass command line arguments through to the executable

### DIFF
--- a/application/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/application/package/ubuntu/multimc/opt/multimc/run.sh
@@ -22,12 +22,12 @@ deploy() {
 
 runmmc() {
     cd ${INSTDIR}
-    ./MultiMC
+    ./MultiMC "$@"
 }
 
 if [[ ! -f ${INSTDIR}/MultiMC ]]; then
     deploy
-    runmmc
+    runmmc "$@"
 else
-    runmmc
+    runmmc "$@"
 fi


### PR DESCRIPTION
The current start script that is placed into `/opt/multimc/run.sh` strips all command line arguments that should be passed back into the main MMC executable. This patch restores it.