### PR TITLE
Operate on copy of QString instead of appending

### DIFF
--- a/api/logic/minecraft/SimpleModList.cpp
+++ b/api/logic/minecraft/SimpleModList.cpp
@@ -133,7 +133,7 @@ bool SimpleModList::installMod(const QString &filename)
 
     if (type == Mod::MOD_SINGLEFILE || type == Mod::MOD_ZIPFILE || type == Mod::MOD_LITEMOD)
     {
-        if(QFile::exists(newpath) || QFile::exists(newpath.append(".disabled")))
+        if(QFile::exists(newpath) || QFile::exists(newpath + QString(".disabled")))
         {
             if(!QFile::remove(newpath))
             {


### PR DESCRIPTION
PR #2689 caused mods being installed via the modlist to be disabled automatically. It uses `QString#append` which operates on the instance itself instead of a copy (and thus is equal to `QString#operator+=`) which causes the extension `.disabled` to be appended to the mod being installed.
This PR fixes it.

There are no open issues for this, however, it was reported earlier this day on Discord by HansWasser
#9034.