### PR TITLE
GH-2515 Save instance ID before display dialog

### DIFF
--- a/api/logic/InstanceList.cpp
+++ b/api/logic/InstanceList.cpp
@@ -234,7 +234,7 @@ void InstanceList::deleteInstance(const InstanceId& id)
     auto inst = getInstanceById(id);
     if(!inst)
     {
-        qDebug() << "Cannot delete instance" << id << " No such instance is present.";
+        qDebug() << "Cannot delete instance" << id << ". No such instance is present (deleted externally?).";
         return;
     }
 

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -1664,6 +1664,7 @@ void MainWindow::on_actionDeleteInstance_triggered()
     {
         return;
     }
+    auto id = m_selectedInstance->id();
     auto response = CustomMessageBox::selectable(
         this,
         tr("CAREFUL!"),
@@ -1674,7 +1675,7 @@ void MainWindow::on_actionDeleteInstance_triggered()
     )->exec();
     if (response == QMessageBox::Yes)
     {
-        MMC->instances()->deleteInstance(m_selectedInstance->id());
+        MMC->instances()->deleteInstance(id);
     }
 }
 


### PR DESCRIPTION
Deleting an instance externally no longer deletes the next instance.