### PR TITLE
Feature/fix hashtag in notes

### DIFF
--- a/api/logic/settings/INIFile.cpp
+++ b/api/logic/settings/INIFile.cpp
@@ -28,49 +28,20 @@ INIFile::INIFile()
 
 QString INIFile::unescape(QString orig)
 {
-    QString out;
-    QChar prev = 0;
-    for(auto c: orig)
-    {
-        if(prev == '\\')
-        {
-            if(c == 'n')
-                out += '\n';
-            else if (c == 't')
-                out += '\t';
-            else
-                out += c;
-            prev = 0;
-        }
-        else
-        {
-            if(c == '\\')
-            {
-                prev = c;
-                continue;
-            }
-            out += c;
-            prev = 0;
-        }
-    }
-    return out;
+    return orig
+        .replace("\\#", "#")
+        .replace("\\t", "\t")
+        .replace("\\n", "\n")
+        .replace("\\\\", "\\");
 }
 
 QString INIFile::escape(QString orig)
 {
-    QString out;
-    for(auto c: orig)
-    {
-        if(c == '\n')
-            out += "\\n";
-        else if (c == '\t')
-            out += "\\t";
-        else if(c == '\\')
-            out += "\\\\";
-        else
-            out += c;
-    }
-    return out;
+    return orig
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('\t', "\\t")
+        .replace('#', "\\#");
 }
 
 bool INIFile::saveFile(QString fileName)
@@ -120,7 +91,15 @@ bool INIFile::loadFile(QByteArray file)
     {
         QString &lineRaw = lines[i];
         // Ignore comments.
-        QString line = lineRaw.left(lineRaw.indexOf('#')).trimmed();
+        int commentIndex = 0;
+        QString line = lineRaw;
+        // Search for comments until no more escaped # are available
+        while((commentIndex = line.indexOf('#', commentIndex + 1)) != -1) {
+            if(commentIndex > 0 && line.at(commentIndex - 1) == '\\') {
+                continue;
+            }
+            line = line.left(lineRaw.indexOf('#')).trimmed();
+        }
 
         int eqPos = line.indexOf('=');
         if (eqPos == -1)

--- a/api/logic/settings/INIFile.cpp
+++ b/api/logic/settings/INIFile.cpp
@@ -28,20 +28,53 @@ INIFile::INIFile()
 
 QString INIFile::unescape(QString orig)
 {
-    return orig
-        .replace("\\#", "#")
-        .replace("\\t", "\t")
-        .replace("\\n", "\n")
-        .replace("\\\\", "\\");
+    QString out;
+    QChar prev = 0;
+    for(auto c: orig)
+    {
+        if(prev == '\\')
+        {
+            if(c == 'n')
+                out += '\n';
+            else if(c == 't')
+                out += '\t';
+            else if(c == '#')
+                out += '#';
+            else
+                out += c;
+            prev = 0;
+        }
+        else
+        {
+            if(c == '\\')
+            {
+                prev = c;
+                continue;
+            }
+            out += c;
+            prev = 0;
+        }
+    }
+    return out;
 }
 
 QString INIFile::escape(QString orig)
 {
-    return orig
-        .replace('\\', "\\\\")
-        .replace('\n', "\\n")
-        .replace('\t', "\\t")
-        .replace('#', "\\#");
+    QString out;
+    for(auto c: orig)
+    {
+        if(c == '\n')
+            out += "\\n";
+        else if (c == '\t')
+            out += "\\t";
+        else if(c == '\\')
+            out += "\\\\";
+        else if(c == '#')
+            out += "\\#";
+        else
+            out += c;
+    }
+    return out;
 }
 
 bool INIFile::saveFile(QString fileName)

--- a/api/logic/settings/INIFile_test.cpp
+++ b/api/logic/settings/INIFile_test.cpp
@@ -26,6 +26,7 @@ slots:
         QTest::newRow("Plain text") << "Lorem ipsum dolor sit amet.";
         QTest::newRow("Escape sequences") << "Lorem\n\t\n\\n\\tAAZ\nipsum dolor\n\nsit amet.";
         QTest::newRow("Escape sequences 2") << "\"\n\n\"";
+        QTest::newRow("Hashtags") << "some data#something";
     }
     void test_Escape()
     {
@@ -40,7 +41,7 @@ slots:
     void test_SaveLoad()
     {
         QString a = "a";
-        QString b = "a\nb\t\n\\\\\\C:\\Program files\\terrible\\name\\of something\\";
+        QString b = "a\nb\t\n\\\\\\C:\\Program files\\terrible\\name\\of something\\#thisIsNotAComment";
         QString filename = "test_SaveLoad.ini";
 
         // save


### PR DESCRIPTION
\# are now escaped when saving and no longer truncate the text