### PR TITLE
Enable HiDPI pixmaps to fix icon scaling for HiDPI displays

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -30,6 +30,7 @@ int main(int argc, char *argv[])
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
      QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
     // initialize Qt


### PR DESCRIPTION
This patch fixes icon scaling (this problem exists for all icons in MultiMC) for HiDPI displays.

Here's a screenshot of what this PR does (top is this, bottom is latest upstream)
![Image](https://cdn.discordapp.com/attachments/411934370983706624/593911788127649843/unknown.png)