### PR TITLE
Update changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ Make sure you have the following packages before you update:
 
 - Arch: `qt5-base`
 - Debian/Ubuntu: `qt5-default`
-- CentOS/RHEL: `qt5-qtbase`
+- CentOS/RHEL/Fedora: `qt5-qtbase-gui`
 - Suse: `libqt5-qtbase`
 
 MultiMC on linux is built with Qt 5.4 and older versions of Qt will not work.


### PR DESCRIPTION
Just installing "qt5-qtbase" on Fedora 30 does not allow MultiMC to run. It still needs "libQt5Widgets.so.5" and by running "dnf whatprovides" it tells me "qt5-qtbase-gui" provides that file and also pulls in "qt5-qtbase" as a dependency if not already installed. I am assuming this is the same situation for CentOS/RHEL