### PR TITLE
Escape ; too in instance folder names

### DIFF
--- a/api/logic/FileSystem.cpp
+++ b/api/logic/FileSystem.cpp
@@ -299,7 +299,7 @@ QString NormalizePath(QString path)
     }
 }
 
-QString badFilenameChars = "\"\\/?<>:*|!+\r\n";
+QString badFilenameChars = "\"\\/?<>:;*|!+\r\n";
 
 QString RemoveInvalidFilenameChars(QString string, QChar replaceWith)
 {


### PR DESCRIPTION
This prevents issues with "lwjgl" or "lwjgl64" not found on Windows.