### PR TITLE
Window Size to 800x600

### DIFF
--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -575,7 +575,7 @@ public:
         {
             MainWindow->setObjectName(QStringLiteral("MainWindow"));
         }
-        MainWindow->resize(694, 563);
+        MainWindow->resize(800, 600);
         MainWindow->setWindowIcon(MMC->getThemedIcon("logo"));
         MainWindow->setWindowTitle("MultiMC 5");
 


### PR DESCRIPTION
Window size brought up enough to where the arrow for the top list (new instance, etc.) is wide enough to not have an arrow by default.