### PR TITLE
Update BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -50,7 +50,7 @@ mkdir ~/MultiMC && cd ~/MultiMC
 mkdir build
 mkdir install
 # clone the complete source
-git clone --recursive git@github.com:MultiMC/MultiMC5.git src
+git clone --recursive https://github.com/MultiMC/MultiMC5.git src
 # configure the project
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=../install ../src


### PR DESCRIPTION
the `git clone` command provided in BUILD.md doesn't work and gives this error on Debian
```
$ git clone --recursive git@github.com:MultiMC/MultiMC5.git src
Cloning into 'src'...
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.113' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
I am suggesting an alternative command to provide to users in BUILD.md instead.