### PR TITLE
Add checks for QT_NO_ACCESSIBILITY to prevent build issues with Qt without accessibility

### DIFF
--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -535,7 +535,9 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         qDebug() << "<> Settings loaded.";
     }
 
+#ifndef QT_NO_ACCESSIBILITY
     QAccessible::installFactory(groupViewAccessibleFactory);
+#endif /* !QT_NO_ACCESSIBILITY */
 
     // load translations
     {

--- a/application/groupview/AccessibleGroupView.cpp
+++ b/application/groupview/AccessibleGroupView.cpp
@@ -6,6 +6,8 @@
 #include <qaccessible.h>
 #include <qheaderview.h>
 
+#ifndef QT_NO_ACCESSIBILITY
+
 QAccessibleInterface *groupViewAccessibleFactory(const QString &classname, QObject *object)
 {
     QAccessibleInterface *iface = 0;
@@ -772,3 +774,5 @@ QAccessibleInterface *AccessibleGroupViewItem::child(int) const
 {
     return 0;
 }
+
+#endif /* !QT_NO_ACCESSIBILITY */

--- a/application/groupview/AccessibleGroupView_p.h
+++ b/application/groupview/AccessibleGroupView_p.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <qtguiglobal.h>
+#ifndef QT_NO_ACCESSIBILITY
 #include "GroupView.h"
 #include "QtCore/qpointer.h"
 #include <QtGui/qaccessible.h>
@@ -114,3 +116,4 @@ private:
 
     friend class AccessibleGroupView;
 };
+#endif /* !QT_NO_ACCESSIBILITY */

--- a/application/groupview/GroupView.cpp
+++ b/application/groupview/GroupView.cpp
@@ -93,11 +93,13 @@ void GroupView::currentChanged(const QModelIndex& current, const QModelIndex& pr
 {
     QAbstractItemView::currentChanged(current, previous);
     // TODO: for accessibility support, implement+register a factory, steal QAccessibleTable from Qt and return an instance of it for GroupView.
+#ifndef QT_NO_ACCESSIBILITY
     if (QAccessible::isActive() && current.isValid()) {
         QAccessibleEvent event(this, QAccessible::Focus);
         event.setChild(current.row());
         QAccessible::updateAccessibility(&event);
     }
+#endif /* !QT_NO_ACCESSIBILITY */
 }
 
 

--- a/application/widgets/VersionListView.cpp
+++ b/application/widgets/VersionListView.cpp
@@ -82,7 +82,9 @@ void VersionListView::setEmptyMode(VersionListView::EmptyMode mode)
 
 void VersionListView::updateEmptyViewPort()
 {
+#ifndef QT_NO_ACCESSIBILITY
     setAccessibleDescription(currentEmptyString());
+#endif /* !QT_NO_ACCESSIBILITY */
 
     if(!m_itemCount)
     {


### PR DESCRIPTION
Remember to add 
```cpp
#ifndef QT_NO_ACCESSIBILITY
```
to future accessibility code to prevent this