### PR TITLE
Tweak GenericName for Linux desktop entry

### DIFF
--- a/application/package/linux/multimc.desktop
+++ b/application/package/linux/multimc.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=MultiMC
-GenericName=MultiMC
+GenericName=Minecraft Launcher
 Comment=Free, open source launcher and instance manager for Minecraft.
 Type=Application
 Terminal=false


### PR DESCRIPTION
This changes what the `GenericName` is in the Linux desktop entry file. The reason is that `GenericName` should be generic, in this case `Minecraft Launcher` since that's what MultiMC is;

> - The `Name` key should only contain the name, or maybe an abbreviation/acronym if available.
> - `GenericName` should state what you would generally call an application that does what this specific application offers (i.e. Firefox is a "Web Browser").
> - `Comment` is intended to contain any useful additional information.

_[wiki.archlinux.org/Desktop_entries#Key_definition](https://wiki.archlinux.org/index.php/Desktop_entries#Key_definition)_