### PR TITLE
feat: add --import command-line option

### DIFF
--- a/application/MainWindow.h
+++ b/application/MainWindow.h
@@ -57,6 +57,8 @@ public:
     void checkInstancePathForProblems();
 
     void updatesAllowedChanged(bool allowed);
+
+    void droppedURLs(QList<QUrl> urls);
 signals:
     void isClosing();
 
@@ -179,8 +181,6 @@ private slots:
      * Runs the DownloadTask and installs updates.
      */
     void downloadUpdates(GoUpdate::Status status);
-
-    void droppedURLs(QList<QUrl> urls);
 
     void konamiTriggered();
 

--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -174,7 +174,7 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         // --alive
         parser.addSwitch("alive");
         parser.addDocumentation("alive", "Write a small '" + liveCheckFile + "' file after MultiMC starts");
-
+        // --import
         parser.addOption("import");
         parser.addShortOpt("import", 'I');
         parser.addDocumentation("import", "Import instance from specified zip (local path or URL)");
@@ -818,8 +818,8 @@ void MultiMC::performMainStartupAction()
         showMainWindow(false);
         qDebug() << "<> Main window shown.";
     }
-
-    if (!m_zipToImport.isEmpty()) {
+    if(!m_zipToImport.isEmpty())
+    {
         qDebug() << "<> Importing instance from zip:" << m_zipToImport.toString();
         QList<QUrl> urls = { m_zipToImport };
         m_mainWindow->droppedURLs(urls);

--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -34,6 +34,7 @@
 #include <QNetworkAccessManager>
 #include <QTranslator>
 #include <QLibraryInfo>
+#include <QList>
 #include <QStringList>
 #include <QDebug>
 #include <QStyleFactory>
@@ -174,6 +175,10 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         parser.addSwitch("alive");
         parser.addDocumentation("alive", "Write a small '" + liveCheckFile + "' file after MultiMC starts");
 
+        parser.addOption("import");
+        parser.addShortOpt("import", 'I');
+        parser.addDocumentation("import", "Import instance from specified zip (local path or URL)");
+
         // parse the arguments
         try
         {
@@ -207,6 +212,7 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
     }
     m_instanceIdToLaunch = args["launch"].toString();
     m_liveCheck = args["alive"].toBool();
+    m_zipToImport = args["import"].toUrl();
 
     QString origcwdPath = QDir::currentPath();
     QString binPath = applicationDirPath();
@@ -811,6 +817,12 @@ void MultiMC::performMainStartupAction()
         // normal main window
         showMainWindow(false);
         qDebug() << "<> Main window shown.";
+    }
+
+    if (!m_zipToImport.isEmpty()) {
+        qDebug() << "<> Importing instance from zip:" << m_zipToImport.toString();
+        QList<QUrl> urls = { m_zipToImport };
+        m_mainWindow->droppedURLs(urls);
     }
 }
 

--- a/application/MultiMC.h
+++ b/application/MultiMC.h
@@ -6,6 +6,7 @@
 #include <QFlag>
 #include <QIcon>
 #include <QDateTime>
+#include <QUrl>
 #include <updater/GoUpdate.h>
 
 #include <BaseInstance.h>
@@ -221,5 +222,6 @@ private:
 public:
     QString m_instanceIdToLaunch;
     bool m_liveCheck = false;
+    QUrl m_zipToImport;
     std::unique_ptr<QFile> logFile;
 };


### PR DESCRIPTION
This pull request adds an `--import` command-line option (and an `-I` short option) which, when specified, makes the "Import from zip" dialog automatically open when the main window is shown, with the URL field's value set to the URL specified as command-line argument.

In order to add this feature, I had to **make `MainWindow::droppedURLs(QList<QUrl>)` public.** I don't know if you're okay with that or not.

Closes #2988