### PR TITLE
Add man page doc

### DIFF
--- a/doc/multimc.1.txt
+++ b/doc/multimc.1.txt
@@ -1,0 +1,62 @@
+MULTIMC(1)
+==========
+:doctype: manpage
+
+
+NAME
+----
+multimc - a launcher and instance manager for Minecraft.
+
+
+SYNOPSIS
+--------
+*multimc* ['OPTIONS']
+
+
+DESCRIPTION
+-----------
+MultiMC is a custom launcher for Minecraft that allows you to easily manage
+multiple installations of Minecraft at once. It also allows you to easily
+install and remove mods by simply dragging and dropping.
+Here are the current features of MultiMC.
+
+OPTIONS
+-------
+*-d, --dir*='DIRECTORY'::
+    Use 'DIRECTORY' as the MultiMC root.
+
+*-l, --launch*='INSTANCE_ID'::
+    Launch the instance specified by 'INSTANCE_ID'.
+
+*--alive*::
+    Write a small 'live.check' file after MultiMC starts.
+
+*-h, --help*::
+    Display help text and exit.
+
+*-v, --version*::
+    Display program version and exit.
+
+EXIT STATUS
+-----------
+*0*::
+    Success
+
+*1*::
+    Failure (syntax or usage error; configuration error; unexpected error).
+
+BUGS
+----
+<https://github.com/MultiMC/MultiMC5/issues>
+
+RESOURCES
+---------
+GitHub: <https://github.com/MultiMC/MultiMC5>
+
+Main website: <https://multimc.org>
+
+AUTHORS
+-------
+peterix <peterix@gmail.com>
+
+// vim: syntax=asciidoc


### PR DESCRIPTION
Adds an asciidoc that can be used to generate a man page. This is additional work so that the environment variable in #2996 can be documented in a man page.

 The AUR PKGFILE will need to be updated to:
 - add `asciidoc` to `makedepends`
 - run `a2x --format manpage`
- install the generated `multimc.1` file at `/usr/share/man/man1/`
 