### PR TITLE
Fix macOS build instructions so that git submodule commands succeed

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -169,9 +169,9 @@ Pick an installation path - this is where the final `.app` will be constructed w
 
 ```
 git clone https://github.com/MultiMC/MultiMC5.git
+cd MultiMC5
 git submodule init
 git submodule update
-cd MultiMC5
 mkdir build
 cd build
 export CMAKE_PREFIX_PATH=/usr/local/opt/qt5


### PR DESCRIPTION
Currently the `git submodule` commands are before the `cd MultiMC5` command. They will fail with the current instructions because the user is not running the `git submodule` commands inside the folder with the git repository, but instead its parent folder.

To resolve this, this PR simply moves the `cd` command before the `git submodule` commands.