### PR TITLE
Remove forgewrapper blocking

### DIFF
--- a/api/logic/minecraft/OneSixVersionFormat.cpp
+++ b/api/logic/minecraft/OneSixVersionFormat.cpp
@@ -151,10 +151,6 @@ VersionFilePtr OneSixVersionFormat::versionFileFromJson(const QJsonDocument &doc
             QJsonObject libObj = requireObject(libVal);
             // parse the library
             auto lib = libraryFromJson(libObj, filename);
-            if(lib->rawName().artifactId() == "ForgeWrapper") {
-                out->mainClass.clear();
-                out->addProblem(ProblemSeverity::Error, QObject::tr("Forge workarounds have no place in MultiMC."));
-            }
             out->libraries.append(lib);
         }
     };


### PR DESCRIPTION
This is just childish. somebody put a lot of work into making forge 1.13+ available for MMC, and you just block it.
To be clear: Nobody expects you to officially support forge 1.13+ if you don't want to, but don't block people from using their favorite launcher working with forge.