### PR TITLE
Stop application freezes on macOS by moving data to MultiMC.app/Data

### DIFF
--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -235,6 +235,10 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
             xdgDataHome = QDir::homePath() + QLatin1String("/.local/share");
         dataPath = xdgDataHome + "/multimc";
         adjustedBy += "XDG standard " + dataPath;
+#elif defined(Q_OS_MAC)
+        QDir foo(FS::PathCombine(applicationDirPath(), "../../Data"));
+        dataPath = foo.absolutePath();
+        adjustedBy += "Fallback to special Mac location " + dataPath;
 #else
         dataPath = applicationDirPath();
         adjustedBy += "Fallback to binary path " + dataPath;


### PR DESCRIPTION
macOS seems to dislike when there is a large amount of non-code items in the `Contents` folder. This causes freezes when clicking on links or buttons leading to external locations from MultiMC (see issue #2529).

A simple solution that maintains portability of MultiMC is to move user data, such as instances, into some folder outside of the `Contents` folder but still inside the application bundle. Here, I've chosen `MultiMC.app/Data`.

This PR will change the locations of the following directories and files from `MultiMC.app/Contents/MacOS` to `MultiMC.app/Data`:

```
mods
accounts
accounts.json
assets
cache
icons
instances
libraries
meta
metacache
MultiMC-0.log
MultiMC-1.log
MultiMC-2.log
MultiMC-3.log
MultiMC-4.log
multimc.cfg
themes
translations
```

To prevent existing users from thinking they've lost their data, MultiMC on macOS will check on startup whether data exists in the old location. If it does, it will be moved to the new location.

This PR may also possibly resolve other issues related to freezes/unresponsiveness on macOS: #2579, #2598, #2784, and #3010. However, as I have not experienced full system freezes caused by MultiMC nor freezes when opening the app, I cannot verify that all of these issues would be resolved, this is simply speculation.

Edit: Seems like it may also resolve long startup times as a result of macOS scanning the app (or whatever it does), so issues like #2473 might also be resolved (I discovered that I experience a long "dock bounce time" on a freshly built or freshly downloaded version of the app when I immediately put a large amount of data somewhere in its `Contents` folder (i.e. the instances) before opening it for the first time)