### PR TITLE
Fix compiling of api/logic/Version.cpp

### DIFF
--- a/api/logic/Version.cpp
+++ b/api/logic/Version.cpp
@@ -78,7 +78,7 @@ void Version::parse()
     // FIXME: this is bad. versions can contain a lot more separators...
     QStringList parts = m_string.split('.');
 
-    for (const auto part : parts)
+    for (const auto &part : parts)
     {
         m_sections.append(Section(part));
     }


### PR DESCRIPTION
When building multimc on my machine (Arch Linux, clang 10 using multimc-git via AUR), the build fails with the following error:

![image](https://user-images.githubusercontent.com/5902494/79673580-09144180-81a9-11ea-8347-a24bd3b242f1.png)

This simply adds a reference as described in the warning turned error.