### PR TITLE
Fixed online saving in early Classic versions

### DIFF
--- a/libraries/launcher/net/minecraft/Launcher.java
+++ b/libraries/launcher/net/minecraft/Launcher.java
@@ -143,7 +143,7 @@ public class Launcher extends Applet implements AppletStub
     public URL getDocumentBase()
     {
         try {
-            return new URL("http://www.minecraft.net/game/");
+            return new URL("http", "www.minecraft.net", 80, "/game/", null);
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Due to how early Classic versions (up to about c0.0.16a_02) read the port parameter from _getDocumentBase()_, the method returns a value of **-1**, instead of a proper port value of **80**, which is read in later Classics.
This makes level saving and loading code non-functional, as it tries to connect with port **-1**.

I've managed to fix that by a simple one line change.