### PR TITLE
Add basic RPM package for RHEL-based Linux distros

### DIFF
--- a/application/package/fedora/multimc/multimc.spec
+++ b/application/package/fedora/multimc/multimc.spec
@@ -1,6 +1,6 @@
 ##Init variables
 
-%global packageVer 1.0
+%global packageVer 1.1
 %global _optdir /opt
 
 ## Package info declaration
@@ -13,9 +13,9 @@ Summary:        Free, open source launcher and instance manager for Minecraft
 License:        ASL 2.0
 URL:            https://multimc.org/
 
-##Only allow build on i686 and x86_64 platforms as MultiMC does not have prebuilt ARM binaries available.
-ExcludeArch:     ARMhfp
-ExcludeArch:     AArch64
+##Builds as noarch, does not install on ARM based machines due to a lack of ARM MultiMC prebuilt binaries.
+BuildArch:      noarch
+ExclusiveArch:  %{ix86} x86_64 noarch
 
 Requires:       bash
 Requires:       java-headless
@@ -70,4 +70,3 @@ EOF
 - Updated in-line documentation
 * Mon Jun 1 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
 - Created initial spec file.
-

--- a/application/package/fedora/multimc/multimc.spec
+++ b/application/package/fedora/multimc/multimc.spec
@@ -30,8 +30,6 @@ Free, open source launcher and instance manager for Minecraft.
 %prep
 
 %setup -q
-cp multimc.svg %{_builddir}/multimc-%{packageVer}/multimc.svg
-cp run.sh %{_builddir}/multimc-%{packageVer}/run.sh
 
 %install
 ##Installs directories

--- a/application/package/fedora/multimc/multimc.spec
+++ b/application/package/fedora/multimc/multimc.spec
@@ -1,6 +1,6 @@
 ##Init variables
 
-%global packageVer 1.2
+%global packageVer 1.3
 %global _optdir /opt
 
 ## Package info declaration
@@ -12,6 +12,7 @@ Summary:        Free, open source launcher and instance manager for Minecraft
 
 License:        ASL 2.0
 URL:            https://multimc.org/
+Source0:        %{name}-%{packageVer}.tar.gz
 
 ##Builds as noarch, does not install on ARM based machines due to a lack of ARM MultiMC prebuilt binaries.
 BuildArch:      noarch
@@ -28,9 +29,9 @@ Free, open source launcher and instance manager for Minecraft.
 
 %prep
 
-%setup -Tc
-cp %{_sourcedir}/multimc.svg %{_builddir}/multimc-%{packageVer}/multimc.svg
-cp %{_sourcedir}/run.sh %{_builddir}/multimc-%{packageVer}/run.sh
+%setup -q
+cp multimc.svg %{_builddir}/multimc-%{packageVer}/multimc.svg
+cp run.sh %{_builddir}/multimc-%{packageVer}/run.sh
 
 %install
 ##Installs directories
@@ -66,9 +67,11 @@ EOF
 %{_optdir}/MultiMC/run.sh
 
 %changelog
+* Thu Jun 18 2019 Jack Greiner <jack@emoss.org> - 1.3-1%{?dist}
+- Fixed builds in Copr.
 * Mon Jun 8 2019 Jack Greiner <jack@emoss.org> - 1.2-1%{?dist}
 - Updated in-line documentation
-* Fri Jun 5 2019 Jack Greiner <jack@emoss.org> - 1.1-1%{?dist}
+* Fri Jun 5 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
 - Updated in-line documentation
 * Mon Jun 1 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
 - Created initial spec file.

--- a/application/package/fedora/multimc/multimc.spec
+++ b/application/package/fedora/multimc/multimc.spec
@@ -65,11 +65,11 @@ EOF
 %{_optdir}/MultiMC/run.sh
 
 %changelog
-* Thu Jun 18 2019 Jack Greiner <jack@emoss.org> - 1.3-1%{?dist}
+* Thu Jun 18 2020 Jack Greiner <jack@emoss.org> - 1.3-1%{?dist}
 - Fixed builds in Copr.
-* Mon Jun 8 2019 Jack Greiner <jack@emoss.org> - 1.2-1%{?dist}
+* Mon Jun 8 2020 Jack Greiner <jack@emoss.org> - 1.2-1%{?dist}
 - Updated in-line documentation
-* Fri Jun 5 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
+* Fri Jun 5 2020 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
 - Updated in-line documentation
-* Mon Jun 1 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
+* Mon Jun 1 2020 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
 - Created initial spec file.

--- a/application/package/fedora/multimc/multimc.spec
+++ b/application/package/fedora/multimc/multimc.spec
@@ -1,6 +1,6 @@
 ##Init variables
 
-%global packageVer 1.1
+%global packageVer 1.2
 %global _optdir /opt
 
 ## Package info declaration
@@ -18,7 +18,7 @@ BuildArch:      noarch
 ExclusiveArch:  %{ix86} x86_64 noarch
 
 Requires:       bash
-Requires:       java-headless
+Requires:       java-1.8.0-openjdk
 Requires:       qt5
 Requires:       zenity
 Requires:       zlib
@@ -66,7 +66,9 @@ EOF
 %{_optdir}/MultiMC/run.sh
 
 %changelog
-* Fri Jun 5 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
+* Mon Jun 8 2019 Jack Greiner <jack@emoss.org> - 1.2-1%{?dist}
+- Updated in-line documentation
+* Fri Jun 5 2019 Jack Greiner <jack@emoss.org> - 1.1-1%{?dist}
 - Updated in-line documentation
 * Mon Jun 1 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
 - Created initial spec file.

--- a/application/package/fedora/multimc/multimc.spec
+++ b/application/package/fedora/multimc/multimc.spec
@@ -1,0 +1,73 @@
+##Init variables
+
+%global packageVer 1.0
+%global _optdir /opt
+
+## Package info declaration
+
+Name:           multimc
+Version:        %{packageVer}
+Release:        1%{?dist}
+Summary:        Free, open source launcher and instance manager for Minecraft
+
+License:        ASL 2.0
+URL:            https://multimc.org/
+
+##Only allow build on i686 and x86_64 platforms as MultiMC does not have prebuilt ARM binaries available.
+ExcludeArch:     ARMhfp
+ExcludeArch:     AArch64
+
+Requires:       bash
+Requires:       java-headless
+Requires:       qt5
+Requires:       zenity
+Requires:       zlib
+
+%description
+Free, open source launcher and instance manager for Minecraft.
+
+%prep
+
+%setup -Tc
+cp %{_sourcedir}/multimc.svg %{_builddir}/multimc-%{packageVer}/multimc.svg
+cp %{_sourcedir}/run.sh %{_builddir}/multimc-%{packageVer}/run.sh
+
+%install
+##Installs directories
+install -dm 755 %{buildroot}/usr/{bin,share/{applications,icons/hicolor/scalable/apps}}
+install -dm 755 %{buildroot}/opt/MultiMC
+
+##Installs icon and run.sh
+install -m 644 %{_builddir}/multimc-%{packageVer}/multimc.svg %{buildroot}/usr/share/icons/hicolor/scalable/apps/multimc.svg
+install -m 755 %{_builddir}/multimc-%{packageVer}/run.sh %{buildroot}%{_optdir}/MultiMC/run.sh
+
+##Generates and installs desktop file to /usr/share/applications
+cat > %{buildroot}/%{_datadir}/applications/%{name}.desktop << EOF
+
+## Desktop File
+
+[Desktop Entry]
+Version=%{packageVer}
+Name=MultiMC
+GenericName=MultiMC Launcher
+Comment=Free, open source launcher and instance manager for Minecraft.
+Type=Application
+Terminal=false
+Exec=%{_optdir}/MultiMC/run.sh
+Icon=multimc
+Categories=Game
+Keywords=game;minecraft;
+EOF
+
+%files
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/scalable/apps/multimc.svg
+%{_optdir}/MultiMC/
+%{_optdir}/MultiMC/run.sh
+
+%changelog
+* Fri Jun 5 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
+- Updated in-line documentation
+* Mon Jun 1 2019 Jack Greiner <jack@emoss.org> - 1.0-1%{?dist}
+- Created initial spec file.
+

--- a/application/package/fedora/multimc/multimc.svg
+++ b/application/package/fedora/multimc/multimc.svg
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="68.26667"
+   height="68.26667"
+   id="svg4427"
+   version="1.1"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="multimc-smooth-biginfinity.svg"
+   inkscape:export-filename="/home/peterix/playground/MultiMC-icons/multimc-smooth-biginfinity.png"
+   inkscape:export-xdpi="180"
+   inkscape:export-ydpi="180">
+  <defs
+     id="defs4429">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4809">
+      <stop
+         style="stop-color:#98c867;stop-opacity:1"
+         offset="0"
+         id="stop4805" />
+      <stop
+         style="stop-color:#5c9a33;stop-opacity:1"
+         offset="1"
+         id="stop4807" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5668"
+       inkscape:collect="always">
+      <stop
+         id="stop5670"
+         offset="0"
+         style="stop-color:#75b54b;stop-opacity:1;" />
+      <stop
+         id="stop5672"
+         offset="1"
+         style="stop-color:#75b54b;stop-opacity:0.6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5084"
+       inkscape:collect="always">
+      <stop
+         id="stop5086"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.8" />
+      <stop
+         id="stop5088"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.35" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5668"
+       id="linearGradient5072"
+       x1="6.7342591"
+       y1="28.510933"
+       x2="50.506943"
+       y2="61.773685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.01532073,-0.00938002)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5084"
+       id="linearGradient5082"
+       x1="14.312115"
+       y1="9.7948904"
+       x2="44.097023"
+       y2="82.973114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5668"
+       id="linearGradient3281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.01532073,-0.00938002)"
+       x1="6.7342591"
+       y1="28.510933"
+       x2="50.506943"
+       y2="61.773685" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5668"
+       id="linearGradient3283"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.01532073,-0.00938002)"
+       x1="6.7342591"
+       y1="28.510933"
+       x2="50.506943"
+       y2="61.773685" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5668"
+       id="linearGradient3286"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2671525,0,0,0.89790119,-0.01941371,-0.00842234)"
+       x1="6.7342591"
+       y1="28.510933"
+       x2="50.506943"
+       y2="61.773685" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5084"
+       id="linearGradient3288"
+       gradientUnits="userSpaceOnUse"
+       x1="14.312115"
+       y1="9.7948904"
+       x2="44.097023"
+       y2="82.973114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5084"
+       id="linearGradient3290"
+       gradientUnits="userSpaceOnUse"
+       x1="14.312115"
+       y1="9.7948904"
+       x2="44.097023"
+       y2="82.973114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5084"
+       id="linearGradient3293"
+       gradientUnits="userSpaceOnUse"
+       x1="14.312115"
+       y1="9.7948904"
+       x2="44.097023"
+       y2="82.973114"
+       gradientTransform="scale(1.2671525,0.89790119)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5580">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.0627451"
+         offset="0"
+         id="stop5576" />
+      <stop
+         style="stop-color:#322217;stop-opacity:0.58823532"
+         offset="1"
+         id="stop5578" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3999"
+       inkscape:collect="always">
+      <stop
+         id="stop3995"
+         offset="0"
+         style="stop-color:#a3704b;stop-opacity:1" />
+      <stop
+         id="stop3997"
+         offset="1"
+         style="stop-color:#6a4a33;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2727"
+       inkscape:collect="always">
+      <stop
+         id="stop2723"
+         offset="0"
+         style="stop-color:#966c4a;stop-opacity:1" />
+      <stop
+         id="stop2725"
+         offset="1"
+         style="stop-color:#593d29;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2727"
+       id="linearGradient2050"
+       gradientUnits="userSpaceOnUse"
+       x1="36.546478"
+       y1="33.80484"
+       x2="86.415741"
+       y2="97.065842" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3999"
+       id="radialGradient2052"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-9.105292e-4,-0.00104444)"
+       cx="34.133331"
+       cy="34.133335"
+       fx="34.133331"
+       fy="34.133335"
+       r="29.866665" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5580"
+       id="linearGradient2140"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0010513,-9.083059e-4)"
+       x1="29.866674"
+       y1="29.867579"
+       x2="38.400005"
+       y2="38.400913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5084"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2671525,0,0,0.89790119,-0.82864077,-1.0012743)"
+       x1="14.312115"
+       y1="9.7948904"
+       x2="44.097023"
+       y2="82.973114" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4809"
+       id="radialGradient4803"
+       cx="-42.66758"
+       cy="-34.134373"
+       fx="-42.66758"
+       fy="-34.134373"
+       r="34.132812"
+       gradientTransform="matrix(1.7500268,0.1250019,-0.01781176,0.24936465,95.393964,18.110151)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.6203867"
+     inkscape:cx="52.171166"
+     inkscape:cy="11.292073"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1368"
+     inkscape:window-height="905"
+     inkscape:window-x="2452"
+     inkscape:window-y="723"
+     inkscape:window-maximized="0"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="false"
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-center="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4446"
+       empspacing="16"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="4.2666667"
+       spacingy="4.2666667"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4432">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g2048"
+       transform="translate(9.113e-4,0.00104183)">
+      <rect
+         rx="8.5333338"
+         ry="8.5333338"
+         style="fill:url(#linearGradient2050);fill-opacity:1;stroke:none;stroke-width:17.06666756"
+         id="rect2026"
+         width="68.26667"
+         height="68.26667"
+         x="-1.3322676e-15"
+         y="3.0270508e-06" />
+      <rect
+         rx="4.2666626"
+         y="4.2656283"
+         x="4.2657552"
+         height="59.733334"
+         width="59.73333"
+         id="rect2028"
+         style="fill:url(#radialGradient2052);fill-opacity:1;stroke:none;stroke-width:14.93333435"
+         ry="4.2666669" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4811"
+         d="m 4.2669272,4.2645856 -9.11e-4,8.5333334 h 4.267577 v 4.267579 h 8.5332038 v 4.265625 h 4.265625 V 8.5322946 H 25.6 v 8.5332034 h 4.265625 v -4.267579 h 4.267578 v 8.533204 h 4.265625 v -4.265625 h 4.267578 v 4.265625 h 4.267579 v -4.265625 h 4.265624 v -4.267579 h 4.267579 v 4.267579 h 8.533203 l -1.3e-4,-12.8009124 z"
+         style="opacity:0.6;fill:#593d29;fill-opacity:1;stroke:none;stroke-width:17.06666756"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccc" />
+      <path
+         style="fill:url(#radialGradient4803);fill-opacity:1;stroke:none;stroke-width:17.06666756"
+         d="m 8.5329442,-0.0018207 c -4.7274675,0 -8.5332035,3.805736 -8.5332035,8.533203 v 4.2675787 h 4.265625 V 8.5313823 c 0,-0.521698 0.105433,-1.01339 0.27539,-1.47461 -0.169616,0.460814 -0.27539,0.953462 -0.27539,1.47461 h 4.2675785 v 4.2675787 h 4.2656248 4.267578 v 4.265625 h 4.265625 V 12.798961 8.5313823 4.2657573 h 4.267578 v 4.265625 4.2675787 h 4.265625 V 8.5313823 h 4.267578 v 4.2675787 4.265625 h 4.265625 v -4.265625 h 4.267578 v 4.265625 h 4.267579 v -4.265625 h 4.265624 V 8.5313823 h 4.267579 v 4.2675787 h 4.265625 4.267578 V 8.5313823 h 4.265625 c 0,-4.727467 -3.805737,-8.533203 -8.533203,-8.533203 z m -3.019531,5.513671 c -0.318089,0.317888 -0.570428,0.695824 -0.7753915,1.101563 0.2048795,-0.405231 0.4576385,-0.784012 0.7753915,-1.101563 z"
+         id="path4794"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:1;fill:url(#linearGradient2140);fill-opacity:1;stroke:none;stroke-width:17.06666756"
+         d="m 8.5322887,-9.083059e-4 c -4.72747,0 -8.5332,3.8057359059 -8.5332,8.5332029059 V 59.731515 c 0,4.727467 3.80573,8.535156 8.5332,8.535156 H 59.731502 c 4.72747,0 8.5332,-3.807689 8.5332,-8.535156 V 8.5322946 c 0,-4.727467 -3.80573,-8.5332029059 -8.5332,-8.5332029059 z m 0,4.2675779059 H 59.731502 c 2.36373,0 4.26758,1.901892 4.26758,4.265625 V 59.731515 c 0,2.363733 -1.90385,4.267578 -4.26758,4.267578 H 8.5322887 c -2.36373,0 -4.26758,-1.903845 -4.26758,-4.267578 V 8.5322946 c 0,-2.363733 1.90385,-4.265625 4.26758,-4.265625 z"
+         id="path2046"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g1092">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4786"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:76.18933868px;line-height:125%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient4790);fill-opacity:1;stroke:none;stroke-width:1.06666672;opacity:0.5"
+         d="m 38.886673,44.940882 c -0.974277,-0.801673 -2.231353,-2.137814 -3.771231,-4.008427 -2.105641,2.672298 -4.085536,4.598569 -5.939688,5.778816 -2.325625,1.425227 -5.295467,2.137836 -8.909534,2.137828 -4.242656,8e-6 -7.762467,-1.124578 -10.5594458,-3.37376 C 6.7526311,43.114834 5.275567,39.986037 5.2755773,36.088937 5.275567,32.347763 6.7526311,29.207831 9.7067742,26.669132 12.346618,24.419991 15.897857,23.295407 20.360501,23.295373 c 2.294138,3.4e-5 4.289747,0.334069 5.986829,1.002107 1.979863,0.73491 3.645488,1.737016 4.996881,3.00632 1.257039,1.135751 2.514115,2.471891 3.771231,4.008428 2.105563,-2.672257 4.085457,-4.598527 5.939689,-5.778816 2.325544,-1.425186 5.295385,-2.137794 8.909533,-2.137828 4.242577,3.4e-5 7.762388,1.124618 10.559447,3.37376 2.954063,2.360546 4.431127,5.489343 4.431197,9.386401 -7e-5,3.741216 -1.477134,6.881147 -4.431197,9.419806 -2.639925,2.24918 -6.191163,3.373767 -10.653727,3.373758 -2.294219,9e-6 -4.289826,-0.334026 -5.98683,-1.002106 -1.697101,-0.601255 -3.362726,-1.603361 -4.996881,-3.006321 M 19.747676,44.473233 c 5.185412,1.1e-5 9.333763,-2.672271 12.445062,-8.016856 -3.991253,-5.834464 -8.139602,-8.751705 -12.445062,-8.751733 -3.142715,2.8e-5 -5.515446,0.801713 -7.118198,2.405057 -1.728498,1.71474 -2.592737,3.707818 -2.592722,5.979236 -1.5e-5,2.494152 0.864224,4.509499 2.592722,6.046046 1.759887,1.558846 4.132618,2.338261 7.118198,2.33825 M 50.483209,27.77145 c -4.682663,2.9e-5 -8.831013,2.672312 -12.445062,8.016856 3.959745,5.834503 8.108095,8.751746 12.445062,8.751733 3.142633,1.3e-5 5.515364,-0.801671 7.118198,-2.405056 1.728416,-1.714701 2.592656,-3.707778 2.592722,-5.979238 -6.6e-5,-2.49411 -0.864306,-4.509456 -2.592722,-6.046044 -1.759968,-1.558805 -4.132699,-2.338222 -7.118198,-2.338251" />
+      <path
+         d="m 39.715314,45.942156 c -0.974277,-0.801673 -2.231353,-2.137814 -3.771231,-4.008427 -2.105641,2.672298 -4.085536,4.598569 -5.939688,5.778816 -2.325625,1.425227 -5.295467,2.137836 -8.909534,2.137828 -4.242656,8e-6 -7.762467,-1.124578 -10.559446,-3.37376 -2.9541431,-2.360505 -4.4312072,-5.489302 -4.4311969,-9.386402 -1.03e-5,-3.741174 1.4770538,-6.881106 4.4311969,-9.419805 2.639844,-2.249141 6.191083,-3.373725 10.653727,-3.373759 2.294138,3.4e-5 4.289747,0.334069 5.986829,1.002107 1.979863,0.73491 3.645488,1.737016 4.996881,3.00632 1.257039,1.135751 2.514115,2.471891 3.771231,4.008428 2.105563,-2.672257 4.085457,-4.598527 5.939689,-5.778816 2.325544,-1.425186 5.295385,-2.137794 8.909533,-2.137828 4.242577,3.4e-5 7.762388,1.124618 10.559447,3.37376 2.954063,2.360546 4.431127,5.489343 4.431197,9.386401 -7e-5,3.741216 -1.477134,6.881147 -4.431197,9.419806 -2.639925,2.24918 -6.191163,3.373767 -10.653727,3.373758 -2.294219,9e-6 -4.289826,-0.334026 -5.98683,-1.002106 -1.697101,-0.601255 -3.362726,-1.603361 -4.996881,-3.006321 M 20.576317,45.474507 c 5.185412,1.1e-5 9.333763,-2.672271 12.445062,-8.016856 -3.991253,-5.834464 -8.139602,-8.751705 -12.445062,-8.751733 -3.142715,2.8e-5 -5.515446,0.801713 -7.118198,2.405057 -1.728498,1.71474 -2.592737,3.707818 -2.592722,5.979236 -1.5e-5,2.494152 0.864224,4.509499 2.592722,6.046046 1.759887,1.558846 4.132618,2.338261 7.118198,2.33825 M 51.31185,28.772724 c -4.682663,2.9e-5 -8.831013,2.672312 -12.445062,8.016856 3.959745,5.834503 8.108095,8.751746 12.445062,8.751733 3.142633,1.3e-5 5.515364,-0.801671 7.118198,-2.405056 1.728416,-1.714701 2.592656,-3.707778 2.592722,-5.979238 -6.6e-5,-2.49411 -0.864306,-4.509456 -2.592722,-6.046044 C 56.67008,29.55217 54.297349,28.772753 51.31185,28.772724"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:76.18933868px;line-height:125%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient3293);fill-opacity:1;stroke:none;stroke-width:1.06666672;opacity:0.5"
+         id="path3279"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 37.904564,42.951873 c -0.974278,-0.801672 -2.231352,-2.137814 -3.771231,-4.008428 -2.105642,2.672298 -4.085537,4.598568 -5.939688,5.778817 -2.325625,1.425227 -5.295466,2.137836 -8.909534,2.137828 -4.242656,8e-6 -7.762467,-1.124577 -10.5594464,-3.37376 -2.9541428,-2.360505 -4.4312068,-5.489302 -4.4311963,-9.386401 -1.05e-5,-3.741175 1.4770535,-6.881107 4.4311963,-9.419805 2.6398444,-2.249142 6.1910824,-3.373727 10.6537284,-3.37376 2.294137,3.3e-5 4.289745,0.334068 5.986829,1.002107 1.979863,0.734909 3.645487,1.737016 4.99688,3.00632 1.257039,1.13575 2.514116,2.471891 3.771231,4.008428 2.105562,-2.672257 4.085456,-4.598528 5.939689,-5.778817 2.325544,-1.425185 5.295387,-2.137795 8.909534,-2.137828 4.242576,3.3e-5 7.762387,1.12462 10.559446,3.373761 2.954062,2.360545 4.431127,5.489343 4.431197,9.386401 -7e-5,3.741216 -1.477135,6.881148 -4.431197,9.419805 -2.639924,2.249182 -6.191164,3.373767 -10.653728,3.37376 -2.294217,7e-6 -4.289826,-0.334028 -5.986828,-1.002107 -1.697101,-0.601254 -3.362727,-1.603361 -4.996882,-3.006321 m -19.138997,-0.46765 c 5.185412,1.3e-5 9.333762,-2.67227 12.445062,-8.016856 -3.991252,-5.834462 -8.139602,-8.751704 -12.445062,-8.751733 -3.142714,2.9e-5 -5.515444,0.801714 -7.118198,2.405056 -1.7284972,1.714743 -2.5927368,3.707819 -2.5927216,5.979239 -1.52e-5,2.49415 0.8642244,4.509496 2.5927216,6.046045 1.759888,1.558845 4.132618,2.338262 7.118198,2.338249 M 49.5011,25.782442 c -4.682663,2.8e-5 -8.831014,2.672311 -12.445063,8.016855 3.959745,5.834504 8.108096,8.751745 12.445063,8.751733 3.142634,1.2e-5 5.515365,-0.801673 7.118198,-2.405056 1.728417,-1.7147 2.592657,-3.707778 2.592721,-5.979238 -6.4e-5,-2.49411 -0.864304,-4.509456 -2.592721,-6.046046 C 54.85933,26.561886 52.486599,25.78247 49.5011,25.782442"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:76.18933868px;line-height:125%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient3286);fill-opacity:1;stroke:none;stroke-width:1.06666672"
+         id="path3272"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscsccccccccccccccccccccscscccccsccscccccc"
+         inkscape:connector-curvature="0"
+         id="text5100"
+         d="m 19.4,21.166667 c -4.462644,3.3e-5 -8.026822,1.150858 -10.6666667,3.4 -2.9541428,2.538698 -4.4333436,5.658825 -4.4333333,9.4 -1.03e-5,3.897098 1.4791905,7.039495 4.4333333,9.4 -1.622701,-2.044271 -2.433341,-4.51168 -2.4333333,-7.4 -1.03e-5,-3.741175 1.4791905,-6.861302 4.433333,-9.4 2.639845,-2.249142 6.204023,-3.399967 10.666667,-3.4 2.294138,3.3e-5 4.302916,0.365295 6,1.033333 1.979862,0.73491 3.615274,1.730695 4.966667,3 0.06836,0.06177 0.131637,0.137049 0.2,0.2 -0.731813,-0.797005 -1.468213,-1.538822 -2.2,-2.2 -1.351393,-1.269305 -2.986805,-2.26509 -4.966667,-3 -1.697084,-0.668038 -3.705862,-1.0333 -6,-1.033333 z m 29.6,0.1 c -3.614148,3.3e-5 -6.574457,0.74148 -8.9,2.166666 -1.818222,1.157367 -3.923451,3.291388 -5.983333,5.883334 0.618278,0.658774 1.248369,1.377605 1.866666,2.133333 2.105562,-2.672257 4.262434,-4.836378 6.116667,-6.016667 2.325543,-1.425186 5.285852,-2.166633 8.9,-2.166666 4.242576,3.3e-5 7.769607,1.150858 10.566667,3.4 -0.570388,-0.722129 -1.227721,-1.382884 -2,-2 C 56.769607,22.417525 53.242576,21.2667 49,21.266667 Z m 8.866667,8.1 c 0.9092,1.305235 1.366619,2.857751 1.366666,4.666666 -6.5e-5,2.271461 -0.871584,4.285301 -2.6,6 -1.602834,1.603384 -3.957366,2.400012 -7.1,2.4 -2.653707,8e-6 -5.320858,-1.032242 -7.833333,-3.216666 3.136636,3.509305 6.469807,5.216676 9.833333,5.216666 3.142634,1.2e-5 5.497166,-0.796616 7.1,-2.4 1.728416,-1.714699 2.599935,-3.728539 2.6,-6 -6.5e-5,-2.49411 -0.871584,-4.496744 -2.6,-6.033333 -0.24943,-0.220921 -0.49262,-0.443723 -0.766666,-0.633333 z m -26.633334,4.966666 c -3.1113,5.344585 -7.247921,8.033345 -12.433333,8.033334 -2.58055,1e-5 -4.543473,-0.352086 -6.208333,-1.516667 0.348871,0.50642 0.590094,0.752276 1.075,1.183333 1.759888,1.558846 4.147753,2.333345 7.133333,2.333334 5.185412,1.1e-5 9.322033,-2.688749 12.433333,-8.033334 z m 4.933334,6.5 c -0.04103,0.05207 -0.09239,0.08182 -0.133334,0.133334 0.687326,0.744419 1.306949,1.359747 1.833334,1.8 -0.529404,-0.580895 -1.078447,-1.178283 -1.7,-1.933334 z"
+         style="font-style:normal;font-weight:normal;font-size:76.18933868px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;opacity:0.3;fill:#ccff00;fill-opacity:1;stroke:none;stroke-width:1.06666672" />
+      <path
+         sodipodi:nodetypes="ccsccscccccccccccccccccccscscccccsccsccccccc"
+         id="text5058-0"
+         d="m 19.730474,21.54714 c -4.462645,3.3e-5 -8.026823,1.150859 -10.6666669,3.4 -2.9541429,2.538699 -4.433344,5.658826 -4.4333333,9.4 -1.07e-5,3.897099 1.4791904,7.039495 4.4333333,9.4 0.042837,0.03444 0.090155,0.06608 0.1333334,0.1 -2.2392086,-2.228193 -3.3666752,-5.040417 -3.3666667,-8.433333 -1.07e-5,-3.741174 1.4791904,-6.861301 4.4333332,-9.4 2.639844,-2.249141 6.204022,-3.399967 10.666667,-3.4 2.294137,3.3e-5 4.302916,0.365295 6,1.033333 1.870874,0.694455 3.42364,1.628367 4.733333,2.8 -0.314265,-0.308986 -0.652406,-0.582729 -0.966667,-0.866666 -1.351393,-1.269305 -2.986804,-2.265091 -4.966666,-3 -1.697084,-0.668039 -3.705863,-1.033301 -6,-1.033334 z m 29.6,0.1 c -3.614149,3.3e-5 -6.574457,0.741481 -8.9,2.166667 -1.813279,1.154221 -3.963039,3.235656 -6.016667,5.816667 0.355649,0.402628 0.711011,0.798625 1.066667,1.233333 2.105561,-2.672257 4.295767,-4.803044 6.15,-5.983333 2.325543,-1.425187 5.285851,-2.166634 8.9,-2.166667 4.22442,3.3e-5 7.742084,1.136734 10.533333,3.366667 -0.36096,-0.367566 -0.745726,-0.696967 -1.166667,-1.033334 -2.797059,-2.249141 -6.32409,-3.399967 -10.566666,-3.4 z m 8.233333,7.333334 c 1.323326,1.449243 1.999942,3.250987 2,5.433333 -6.5e-5,2.27146 -0.871584,4.2853 -2.6,6 -1.602834,1.603383 -3.957366,2.400012 -7.1,2.4 -2.406328,6e-6 -4.776468,-0.90386 -7.066667,-2.7 2.669147,2.483838 5.436929,3.766674 8.266667,3.766667 3.142634,1.1e-5 5.497166,-0.796617 7.1,-2.4 1.728416,-1.7147 2.599935,-3.72854 2.6,-6 -6.5e-5,-2.49411 -0.871584,-4.496745 -2.6,-6.033334 -0.185641,-0.164422 -0.400724,-0.319587 -0.6,-0.466666 z m -26,5.733333 c -3.1113,5.344584 -7.247921,8.033345 -12.433333,8.033333 -2.612382,1.1e-5 -4.759372,-0.60651 -6.433334,-1.8 0.166027,0.176488 0.313947,0.367942 0.5,0.533334 1.759888,1.558845 4.147754,2.333345 7.133334,2.333333 5.185412,1.2e-5 9.322033,-2.688749 12.433333,-8.033333 z m 4.133333,5.566667 c -0.04657,0.05909 -0.08689,0.108298 -0.133333,0.166666 1.038571,1.18897 1.9748,2.169945 2.7,2.766667 0.06249,0.05364 0.137426,0.08086 0.2,0.133333 -0.792178,-0.781249 -1.706288,-1.778539 -2.766667,-3.066666 z"
+         style="font-style:normal;font-weight:normal;font-size:76.18933868px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;opacity:0.6;fill:#ccff00;fill-opacity:1;stroke:none;stroke-width:1.06666672"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/application/package/fedora/multimc/run.sh
+++ b/application/package/fedora/multimc/run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+INSTDIR="${XDG_DATA_HOME-$HOME/.local/share}/multimc"
+
+if [ `getconf LONG_BIT` = "64" ]
+then
+    PACKAGE="mmc-stable-lin64.tar.gz"
+else
+    PACKAGE="mmc-stable-lin32.tar.gz"
+fi
+
+deploy() {
+    mkdir -p $INSTDIR
+    cd ${INSTDIR}
+
+    wget --progress=dot:force "https://files.multimc.org/downloads/${PACKAGE}" 2>&1 | sed -u 's/.* \([0-9]\+%\)\ \+\([0-9.]\+.\) \(.*\)/\1\n# Downloading at \2\/s, ETA \3/' | zenity --progress --auto-close --auto-kill --title="Downloading MultiMC..."
+
+    tar -xzf ${PACKAGE} --transform='s,MultiMC/,,'
+    rm ${PACKAGE}
+    chmod +x MultiMC
+}
+
+runmmc() {
+    cd ${INSTDIR}
+    ./MultiMC "$@"
+}
+
+if [[ ! -f ${INSTDIR}/MultiMC ]]; then
+    deploy
+    runmmc "$@"
+else
+    runmmc "$@"
+fi

--- a/application/package/fedora/readme.md
+++ b/application/package/fedora/readme.md
@@ -1,0 +1,18 @@
+# What is this?
+A simple Fedora package (based on the one for Ubuntu) which includes a script that downloads the latest version of MultiMC into the user's home directory.
+
+When installed it will install a shell script (`run.sh`) to `/opt/MultiMC`, an icon `multimc.svg` to `/usr/share/icons/hicolor/scalable/apps`, and a `.desktop` file to `/usr/share/applications`
+
+# How to build this?
+Refer to the Fedora Packaging documentation [here](https://docs.fedoraproject.org/en-US/quick-docs/creating-rpm-packages/#preparing-your-system-to-create-rpm-packages) to initially configure your environment.
+
+Once this environment is configured, run the following within the `multimc` folder
+
+```
+fedpkg --release f32 local
+```
+You can find the release build of the package in the x86_64 or i386 folder, a source RPM will be generated as well.
+
+Replace the release with whichever version of Fedora you are packaging for. 
+
+This package can be built for x86_64 or i686 platforms (32bit Fedora is soon to be EOL so this may be subject to change)


### PR DESCRIPTION
Title.

I saw another pull request of this nature and figured I'd create one that doesn't require any source binaries to be built.

This is literally a carbon copy of the Debian package but for Fedora, should work for x86_64 and i386.