### PR TITLE
Add support for custom meta URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror=return-type")
 
 ######## Set URLs ########
 set(MultiMC_NEWS_RSS_URL "https://multimc.org/rss.xml" CACHE STRING "URL to fetch MultiMC's news RSS feed from.")
+set(MultiMC_META_URL "https://meta.multimc.org/v1/" CACHE STRING "URL to fetch MultiMC's meta files from.")
 
 ######## Set version numbers ########
 set(MultiMC_VERSION_MAJOR    0)

--- a/api/logic/CMakeLists.txt
+++ b/api/logic/CMakeLists.txt
@@ -3,7 +3,7 @@ project(MultiMC_logic)
 include (UnitTest)
 
 # Add meta url to meta file
-configure_file("meta/BaseEntity.cpp.in" "meta/BaseEntity.cpp")
+configure_file("${PROJECT_SOURCE_DIR}/meta/BaseEntity.cpp.in" "${PROJECT_BINARY_DIR}/meta/BaseEntity.cpp")
 
 set(CORE_SOURCES
     # LOGIC - Base classes and infrastructure
@@ -427,8 +427,8 @@ set(META_SOURCES
     # Metadata sources
     meta/JsonFormat.cpp
     meta/JsonFormat.h
-    meta/BaseEntity.cpp
     meta/BaseEntity.h
+    ${PROJECT_BINARY_DIR}/meta/BaseEntity.cpp
     meta/VersionList.cpp
     meta/VersionList.h
     meta/Version.cpp

--- a/api/logic/CMakeLists.txt
+++ b/api/logic/CMakeLists.txt
@@ -2,6 +2,9 @@ project(MultiMC_logic)
 
 include (UnitTest)
 
+# Add meta url to meta file
+configure_file("meta/BaseEntity.cpp.in" "meta/BaseEntity.cpp")
+
 set(CORE_SOURCES
     # LOGIC - Base classes and infrastructure
     BaseInstaller.h

--- a/api/logic/meta/BaseEntity.cpp.in
+++ b/api/logic/meta/BaseEntity.cpp.in
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "BaseEntity.h"
+#include "meta/BaseEntity.h"
 
 #include "Json.h"
 

--- a/api/logic/meta/BaseEntity.cpp.in
+++ b/api/logic/meta/BaseEntity.cpp.in
@@ -76,7 +76,7 @@ Meta::BaseEntity::~BaseEntity()
 
 QUrl Meta::BaseEntity::url() const
 {
-    return QUrl(@MultiMC_META_URL@).resolved(localFilename());
+    return QUrl("@MultiMC_META_URL@").resolved(localFilename());
 }
 
 bool Meta::BaseEntity::loadLocalFile()

--- a/api/logic/meta/BaseEntity.cpp.in
+++ b/api/logic/meta/BaseEntity.cpp.in
@@ -76,7 +76,7 @@ Meta::BaseEntity::~BaseEntity()
 
 QUrl Meta::BaseEntity::url() const
 {
-    return QUrl("https://meta.multimc.org/v1/").resolved(localFilename());
+    return QUrl(@MultiMC_META_URL@).resolved(localFilename());
 }
 
 bool Meta::BaseEntity::loadLocalFile()


### PR DESCRIPTION
Allows a custom meta URL to be specified when building.
Eg. `cmake -D MultiMC_META_URL:STRING="https://meta.multimc.org/v1/"`