### PR TITLE
Minor: Render the skin overlay in SkinUtils

### DIFF
--- a/api/gui/SkinUtils.cpp
+++ b/api/gui/SkinUtils.cpp
@@ -18,6 +18,7 @@
 #include "Env.h"
 
 #include <QFile>
+#include <QPainter>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -35,10 +36,14 @@ QPixmap getFaceFromCache(QString username, int height, int width)
 
     if (fskin.exists())
     {
-        QPixmap skin(fskin.fileName());
-        if(!skin.isNull())
+        QPixmap skinTexture(fskin.fileName());
+        if(!skinTexture.isNull())
         {
-            return skin.copy(8, 8, 8, 8).scaled(height, width, Qt::KeepAspectRatio);
+            QPixmap skin = QPixmap(8, 8);
+            QPainter painter(&skin);
+            painter.drawPixmap(0, 0, skinTexture.copy(8, 8, 8, 8));
+            painter.drawPixmap(0, 0, skinTexture.copy(40, 8, 8, 8));
+            return skin.scaled(height, width, Qt::KeepAspectRatio);
         }
     }
 


### PR DESCRIPTION
Currently, MultiMC doesn't render the skin overlay on the player's head:
![image](https://user-images.githubusercontent.com/9999055/87252972-7a495500-c477-11ea-86ad-7382ea4052f3.png)

This patch changes this and renders a more accurate version of it:
![image](https://user-images.githubusercontent.com/9999055/87252975-7fa69f80-c477-11ea-9ce3-e795dbad7d80.png)
