### PR TITLE
Enable -Wmissing-declarations warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,12 @@ add_subdirectory(libraries/classparser) # google analytics library
 
 ############################### Built Artifacts ###############################
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-prototypes")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-declarations")
+endif()
+
 add_subdirectory(buildconfig)
 add_subdirectory(api/logic)
 add_subdirectory(api/gui)

--- a/api/gui/icons/MMCIcon.cpp
+++ b/api/gui/icons/MMCIcon.cpp
@@ -17,7 +17,7 @@
 #include <QFileInfo>
 #include <xdgicon.h>
 
-IconType operator--(IconType &t, int)
+static IconType operator--(IconType &t, int)
 {
     IconType temp = t;
     switch (t)

--- a/api/logic/FileSystem.cpp
+++ b/api/logic/FileSystem.cpp
@@ -27,7 +27,7 @@
 
 namespace FS {
 
-void ensureExists(const QDir &dir)
+static void ensureExists(const QDir &dir)
 {
     if (!QDir().mkpath(dir.absolutePath()))
     {

--- a/api/logic/GZip_test.cpp
+++ b/api/logic/GZip_test.cpp
@@ -4,7 +4,7 @@
 #include "GZip.h"
 #include <random>
 
-void fib(int &prev, int &cur)
+static void fib(int &prev, int &cur)
 {
     auto ret = prev + cur;
     prev = cur;

--- a/api/logic/LoggedProcess.cpp
+++ b/api/logic/LoggedProcess.cpp
@@ -20,7 +20,7 @@ LoggedProcess::~LoggedProcess()
     }
 }
 
-QStringList reprocess(const QByteArray & data, QString & leftover)
+static QStringList reprocess(const QByteArray & data, QString & leftover)
 {
     QString str = leftover + QString::fromLocal8Bit(data);
 

--- a/api/logic/java/JavaInstallList.cpp
+++ b/api/logic/java/JavaInstallList.cpp
@@ -118,7 +118,7 @@ void JavaInstallList::updateListData(QList<BaseVersionPtr> versions)
     m_loadTask.reset();
 }
 
-bool sortJavas(BaseVersionPtr left, BaseVersionPtr right)
+static bool sortJavas(BaseVersionPtr left, BaseVersionPtr right)
 {
     auto rleft = std::dynamic_pointer_cast<JavaInstall>(left);
     auto rright = std::dynamic_pointer_cast<JavaInstall>(right);

--- a/api/logic/minecraft/Rule.cpp
+++ b/api/logic/minecraft/Rule.cpp
@@ -18,7 +18,7 @@
 
 #include "Rule.h"
 
-RuleAction RuleAction_fromString(QString name)
+static RuleAction RuleAction_fromString(QString name)
 {
     if (name == "allow")
         return Allow;

--- a/api/logic/minecraft/SkinUpload.cpp
+++ b/api/logic/minecraft/SkinUpload.cpp
@@ -3,7 +3,7 @@
 #include <QHttpMultiPart>
 #include <Env.h>
 
-QByteArray getModelString(SkinUpload::Model model) {
+static QByteArray getModelString(SkinUpload::Model model) {
     switch (model) {
         case SkinUpload::STEVE:
             return "";

--- a/api/logic/minecraft/World.cpp
+++ b/api/logic/minecraft/World.cpp
@@ -50,7 +50,7 @@ QString gameTypeToString(GameType type)
     return QObject::tr("Unknown");
 }
 
-std::unique_ptr <nbt::tag_compound> parseLevelDat(QByteArray data)
+static std::unique_ptr <nbt::tag_compound> parseLevelDat(QByteArray data)
 {
     QByteArray output;
     if(!GZip::unzip(data, output))
@@ -69,7 +69,7 @@ std::unique_ptr <nbt::tag_compound> parseLevelDat(QByteArray data)
     return std::move(pair.second);
 }
 
-QByteArray serializeLevelDat(nbt::tag_compound * levelInfo)
+static QByteArray serializeLevelDat(nbt::tag_compound * levelInfo)
 {
     std::ostringstream s;
     nbt::io::write_tag("", *levelInfo, s);
@@ -77,7 +77,7 @@ QByteArray serializeLevelDat(nbt::tag_compound * levelInfo)
     return val;
 }
 
-QString getLevelDatFromFS(const QFileInfo &file)
+static QString getLevelDatFromFS(const QFileInfo &file)
 {
     QDir worldDir(file.filePath());
     if(!file.isDir() || !worldDir.exists("level.dat"))
@@ -87,7 +87,7 @@ QString getLevelDatFromFS(const QFileInfo &file)
     return worldDir.absoluteFilePath("level.dat");
 }
 
-QByteArray getLevelDatDataFromFS(const QFileInfo &file)
+static QByteArray getLevelDatDataFromFS(const QFileInfo &file)
 {
     auto fullFilePath = getLevelDatFromFS(file);
     if(fullFilePath.isNull())
@@ -102,7 +102,7 @@ QByteArray getLevelDatDataFromFS(const QFileInfo &file)
     return f.readAll();
 }
 
-bool putLevelDatDataToFS(const QFileInfo &file, QByteArray & data)
+static bool putLevelDatDataToFS(const QFileInfo &file, QByteArray & data)
 {
     auto fullFilePath =  getLevelDatFromFS(file);
     if(fullFilePath.isNull())

--- a/api/logic/minecraft/launch/LauncherPartLaunch.cpp
+++ b/api/logic/minecraft/launch/LauncherPartLaunch.cpp
@@ -46,13 +46,12 @@ QString shortPathName(const QString & file)
     QString ret = QString::fromStdWString(output);
     return ret;
 }
-#endif
-
 // if the string survives roundtrip through local 8bit encoding...
-bool fitsInLocal8bit(const QString & string)
+static bool fitsInLocal8bit(const QString & string)
 {
     return string == QString::fromLocal8Bit(string.toLocal8Bit());
 }
+#endif
 
 void LauncherPartLaunch::executeTask()
 {

--- a/api/logic/notifications/NotificationChecker.cpp
+++ b/api/logic/notifications/NotificationChecker.cpp
@@ -101,7 +101,7 @@ void NotificationChecker::downloadSucceeded(int)
     emit notificationCheckFinished();
 }
 
-bool versionLessThan(const QString &v1, const QString &v2)
+static bool versionLessThan(const QString &v1, const QString &v2)
 {
     QStringList l1 = v1.split('.');
     QStringList l2 = v2.split('.');

--- a/api/logic/updater/DownloadTask_test.cpp
+++ b/api/logic/updater/DownloadTask_test.cpp
@@ -10,7 +10,7 @@
 
 using namespace GoUpdate;
 
-FileSourceList encodeBaseFile(const char *suffix)
+static FileSourceList encodeBaseFile(const char *suffix)
 {
     auto base = QDir::currentPath();
     QUrl localFile = QUrl::fromLocalFile(base + suffix);
@@ -22,21 +22,7 @@ FileSourceList encodeBaseFile(const char *suffix)
 Q_DECLARE_METATYPE(VersionFileList)
 Q_DECLARE_METATYPE(Operation)
 
-QDebug operator<<(QDebug dbg, const FileSource &f)
-{
-    dbg.nospace() << "FileSource(type=" << f.type << " url=" << f.url
-                  << " comp=" << f.compressionType << ")";
-    return dbg.maybeSpace();
-}
-
-QDebug operator<<(QDebug dbg, const VersionFileEntry &v)
-{
-    dbg.nospace() << "VersionFileEntry(path=" << v.path << " mode=" << v.mode
-                  << " md5=" << v.md5 << " sources=" << v.sources << ")";
-    return dbg.maybeSpace();
-}
-
-QDebug operator<<(QDebug dbg, const Operation::Type &t)
+static QDebug operator<<(QDebug dbg, const Operation::Type &t)
 {
     switch (t)
     {
@@ -50,7 +36,7 @@ QDebug operator<<(QDebug dbg, const Operation::Type &t)
     return dbg.maybeSpace();
 }
 
-QDebug operator<<(QDebug dbg, const Operation &u)
+static QDebug operator<<(QDebug dbg, const Operation &u)
 {
     dbg.nospace() << "Operation(type=" << u.type << " file=" << u.source
                   << " dest=" << u.destination << " mode=" << u.destinationMode << ")";

--- a/api/logic/updater/UpdateChecker_test.cpp
+++ b/api/logic/updater/UpdateChecker_test.cpp
@@ -6,7 +6,7 @@
 
 Q_DECLARE_METATYPE(UpdateChecker::ChannelListEntry)
 
-bool operator==(const UpdateChecker::ChannelListEntry &e1, const UpdateChecker::ChannelListEntry &e2)
+static bool operator==(const UpdateChecker::ChannelListEntry &e1, const UpdateChecker::ChannelListEntry &e2)
 {
     qDebug() << e1.url << "vs" << e2.url;
     return e1.id == e2.id &&
@@ -15,13 +15,7 @@ bool operator==(const UpdateChecker::ChannelListEntry &e1, const UpdateChecker::
             e1.url == e2.url;
 }
 
-QDebug operator<<(QDebug dbg, const UpdateChecker::ChannelListEntry &c)
-{
-    dbg.nospace() << "ChannelListEntry(id=" << c.id << " name=" << c.name << " description=" << c.description << " url=" << c.url << ")";
-    return dbg.maybeSpace();
-}
-
-QString findTestDataUrl(const char *file)
+static QString findTestDataUrl(const char *file)
 {
     return QUrl::fromLocalFile(QFINDTESTDATA(file)).toString();
 }

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -996,7 +996,7 @@ void MainWindow::updateToolsMenu()
     ui->actionLaunchInstanceOffline->setMenu(launchOfflineMenu);
 }
 
-QString profileInUseFilter(const QString & profile, bool used)
+static QString profileInUseFilter(const QString & profile, bool used)
 {
     if(used)
     {
@@ -1213,7 +1213,7 @@ void MainWindow::updateNotAvailable()
     dlg.exec();
 }
 
-QList<int> stringToIntList(const QString &string)
+static QList<int> stringToIntList(const QString &string)
 {
     QStringList split = string.split(',', QString::SkipEmptyParts);
     QList<int> out;
@@ -1223,7 +1223,7 @@ QList<int> stringToIntList(const QString &string)
     }
     return out;
 }
-QString intListToString(const QList<int> &list)
+static QString intListToString(const QList<int> &list)
 {
     QStringList slist;
     for (int i = 0; i < list.size(); ++i)

--- a/application/dialogs/ExportInstanceDialog.cpp
+++ b/application/dialogs/ExportInstanceDialog.cpp
@@ -338,7 +338,7 @@ ExportInstanceDialog::~ExportInstanceDialog()
 }
 
 /// Save icon to instance's folder is needed
-void SaveIcon(InstancePtr m_instance)
+static void SaveIcon(InstancePtr m_instance)
 {
     auto iconKey = m_instance->iconKey();
     auto iconList = MMC->icons();

--- a/application/dialogs/UpdateDialog.cpp
+++ b/application/dialogs/UpdateDialog.cpp
@@ -52,7 +52,7 @@ void UpdateDialog::loadChangelog()
     dljob->start();
 }
 
-QString reprocessMarkdown(QByteArray markdown)
+static QString reprocessMarkdown(QByteArray markdown)
 {
     HoeDown hoedown;
     QString output = hoedown.process(markdown);
@@ -63,7 +63,7 @@ QString reprocessMarkdown(QByteArray markdown)
     return output;
 }
 
-QString reprocessCommits(QByteArray json)
+static QString reprocessCommits(QByteArray json)
 {
     auto channel = MMC->settings()->get("UpdateChannel").toString();
     try

--- a/application/groupview/InstanceDelegate.cpp
+++ b/application/groupview/InstanceDelegate.cpp
@@ -54,7 +54,7 @@ ListViewDelegate::ListViewDelegate(QObject *parent) : QStyledItemDelegate(parent
 {
 }
 
-void drawSelectionRect(QPainter *painter, const QStyleOptionViewItem &option,
+static void drawSelectionRect(QPainter *painter, const QStyleOptionViewItem &option,
                        const QRect &rect)
 {
     if ((option.state & QStyle::State_Selected))
@@ -67,7 +67,8 @@ void drawSelectionRect(QPainter *painter, const QStyleOptionViewItem &option,
     }
 }
 
-void drawFocusRect(QPainter *painter, const QStyleOptionViewItem &option, const QRect &rect)
+/* FIXME: unused
+static void drawFocusRect(QPainter *painter, const QStyleOptionViewItem &option, const QRect &rect)
 {
     if (!(option.state & QStyle::State_HasFocus))
         return;
@@ -89,9 +90,10 @@ void drawFocusRect(QPainter *painter, const QStyleOptionViewItem &option, const 
 
     painter->setRenderHint(QPainter::Antialiasing);
 }
+*/
 
 // TODO this can be made a lot prettier
-void drawProgressOverlay(QPainter *painter, const QStyleOptionViewItem &option,
+static void drawProgressOverlay(QPainter *painter, const QStyleOptionViewItem &option,
                          const int value, const int maximum)
 {
     if (maximum == 0 || value == maximum)
@@ -111,7 +113,7 @@ void drawProgressOverlay(QPainter *painter, const QStyleOptionViewItem &option,
     painter->restore();
 }
 
-void drawBadges(QPainter *painter, const QStyleOptionViewItem &option, BaseInstance *instance, QIcon::Mode mode, QIcon::State state)
+static void drawBadges(QPainter *painter, const QStyleOptionViewItem &option, BaseInstance *instance, QIcon::Mode mode, QIcon::State state)
 {
     QList<QString> pixmaps;
     if (instance->isRunning())


### PR DESCRIPTION
This warns whenever a function (other than a `static` or `inline` one) is defined without a separate declaration. This ensures that file-local functions get marked as `static` as they should be. This helps the compiler recognize dead code more effectively (the `-Wunused-function` warning, enabled by `-Wall`, can only recognise unused static functions.) It also helps the optimizer inline more aggressively (as it knows every call site of a static function).