### PR TITLE
NOISSUE Use new modpacks.ch route for listing packs

### DIFF
--- a/application/pages/modplatform/ftb/FtbModel.cpp
+++ b/application/pages/modplatform/ftb/FtbModel.cpp
@@ -79,7 +79,7 @@ void ListModel::performSearch()
     auto *netJob = new NetJob("Ftb::Search");
     QString searchUrl;
     if(currentSearchTerm.isEmpty()) {
-        searchUrl = BuildConfig.MODPACKSCH_API_BASE_URL + "public/modpack/popular/plays/100";
+        searchUrl = BuildConfig.MODPACKSCH_API_BASE_URL + "public/modpack/all";
     }
     else {
         searchUrl = QString(BuildConfig.MODPACKSCH_API_BASE_URL + "public/modpack/search/25?term=%1")


### PR DESCRIPTION
This would ideally be paired with GH-3442 since this has packs in reverse chronological order, GH-3442 would present packs in a reasonable (and changeable) manor.