### PR TITLE
NOISSUE Ignore 'dud' FTB packs

### DIFF
--- a/application/pages/modplatform/ftb/FtbModel.cpp
+++ b/application/pages/modplatform/ftb/FtbModel.cpp
@@ -206,6 +206,14 @@ void ListModel::packRequestFinished()
         return;
     }
 
+    // Since there is no guarantee that packs have a version, this will just
+    // ignore those "dud" packs.
+    if (pack.versions.empty())
+    {
+        qWarning() << "FTB Pack " << pack.id << " ignored. reason: lacking any versions";
+        return;
+    }
+
     beginInsertRows(QModelIndex(), modpacks.size(), modpacks.size());
     modpacks.append(pack);
     endInsertRows();


### PR DESCRIPTION
There is no guarantee from modpacks.ch that modpacks contain any
versions, which is currently an issue with pack 63 (Direwolf20 1.5).