### PR TITLE
NOISSUE Move fabric up in the modloaders list

### DIFF
--- a/application/pages/instance/VersionPage.ui
+++ b/application/pages/instance/VersionPage.ui
@@ -158,20 +158,20 @@
     <string>Revert the selected package to default.</string>
    </property>
   </action>
-  <action name="actionInstall_Forge">
-   <property name="text">
-    <string>Install Forge</string>
-   </property>
-   <property name="toolTip">
-    <string>Install the Minecraft Forge package.</string>
-   </property>
-  </action>
   <action name="actionInstall_Fabric">
    <property name="text">
     <string>Install Fabric</string>
    </property>
    <property name="toolTip">
     <string>Install the Fabric Loader package.</string>
+   </property>
+  </action>
+  <action name="actionInstall_Forge">
+   <property name="text">
+    <string>Install Forge</string>
+   </property>
+   <property name="toolTip">
+    <string>Install the Minecraft Forge package.</string>
    </property>
   </action>
   <action name="actionInstall_LiteLoader">


### PR DESCRIPTION
Fabric is now widely regarded as the preferred modloader for Minecraft, also updating much quicker than its older (however still modern-ish) counterpart, Forge, and I think it would be more intuitive for it to be moved up the list.