### PR TITLE
Switch Session Server

### DIFF
--- a/application/widgets/ServerStatus.cpp
+++ b/application/widgets/ServerStatus.cpp
@@ -65,7 +65,7 @@ ServerStatus::ServerStatus(QWidget *parent, Qt::WindowFlags f) : QWidget(parent,
 
     addStatus("authserver.mojang.com", tr("Auth"));
     addLine();
-    addStatus("sessionserver.mojang.com", tr("Session"));
+    addStatus("session.minecraft.net", tr("Session"));
     addLine();
     addStatus("textures.minecraft.net", tr("Skins"));
     addLine();


### PR DESCRIPTION
sessionserver.mojang.com has been down for a while and it looks like it is no longer in use.
[Link to where Mojang says it is not in use](https://bugs.mojang.com/browse/WEB-3166?focusedCommentId=820167&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-820167)

I have switched the URL to session.minecraft.net