### PR TITLE
NOISSUE Creates editorconfig to enforce spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
 [*]
 indent_style = space
 charset = utf-8
+indent_size = 4
 trim_trailing_whitespace = true


### PR DESCRIPTION
This pr enforces the space indentation (assuming the IDE can read `.editorconfig`)