### PR TITLE
Fix #3602: Add a .minecraft folder before pre-launch commands are run

### DIFF
--- a/api/logic/launch/steps/PreLaunchCommand.cpp
+++ b/api/logic/launch/steps/PreLaunchCommand.cpp
@@ -22,10 +22,12 @@ PreLaunchCommand::PreLaunchCommand(LaunchTask *parent) : LaunchStep(parent)
     auto instance = m_parent->instance();
     m_command = instance->getPreLaunchCommand();
     //This checks if the .minecraft folder exists, because without that folder, the pre-launch command will always crash
-    if (QFileInfo(FS::PathCombine(instance->instanceRoot(), "minecraft")).absoluteDir().exists() && !QFileInfo(FS::PathCombine(instance->instanceRoot(), ".minecraft")).absoluteDir().exists()) {
-        FS::ensureFolderPathExists(FS::PathCombine(instance->instanceRoot(), "minecraft"));
+    QString mcDir = FS::PathCombine(instance->instanceRoot(), "minecraft");
+    QString dotMcDir = FS::PathCombine(instance->instanceRoot(), ".minecraft");
+    if (QFileInfo(mcDir).absoluteDir().exists() && !QFileInfo(dotMcDir).absoluteDir().exists()) {
+        FS::ensureFolderPathExists(mcDir);
     } else {
-        FS::ensureFolderPathExists(FS::PathCombine(instance->instanceRoot(), ".minecraft"));
+        FS::ensureFolderPathExists(dotMcDir);
     }
     m_process.setProcessEnvironment(instance->createEnvironment());
     connect(&m_process, &LoggedProcess::log, this, &PreLaunchCommand::logLines);

--- a/api/logic/launch/steps/PreLaunchCommand.cpp
+++ b/api/logic/launch/steps/PreLaunchCommand.cpp
@@ -34,7 +34,6 @@ PreLaunchCommand::PreLaunchCommand(LaunchTask *parent) : LaunchStep(parent)
 
 void PreLaunchCommand::executeTask()
 {
-
     //FIXME: where to put this?
     QString prelaunch_cmd = m_parent->substituteVariables(m_command);
     emit logLine(tr("Running Pre-Launch command: %1").arg(prelaunch_cmd), MessageLevel::MultiMC);


### PR DESCRIPTION
Added some logic to ensure the .minecraft folder exists before running a pre-launch command, as not doing so can sometimes cause the instance to not run. This is to fix #3602 