### PR TITLE
GH-3666 Fix multi-monitor dpi scaling on windows

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -4,6 +4,10 @@
 #include <InstanceList.h>
 #include <QDebug>
 
+#ifdef Q_OS_WIN
+    #include<windows.h>
+#endif
+
 // #define BREAK_INFINITE_LOOP
 // #define BREAK_EXCEPTION
 // #define BREAK_RETURN
@@ -29,7 +33,19 @@ int main(int argc, char *argv[])
 #endif
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    #ifdef Q_OS_WIN
+        BOOL (__stdcall *pFn)(void);
+        HINSTANCE hInstance=LoadLibrary("user32.dll");
+        if(hInstance) {
+            pFn = (BOOL (__stdcall*)(void))GetProcAddress(hInstance, "SetProcessDPIAware");
+            if(pFn)
+                pFn();
+            FreeLibrary(hInstance);
+        }
+        QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+    #else
+        QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    #endif
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 


### PR DESCRIPTION
Disable qt 5.6 DPI scaling and use windows' builtin DPI scaling, which fixes scaling issues on windows multi-monitor setups with different resolutions.

Tested on Windows 10 version 2004 build 19041.867 using build instructions described [here](https://github.com/MultiMC/MultiMC5/blob/develop/BUILD.md).

Fixes GH-3666