### PR TITLE
NOISSUE Fix edgecase where new searches won't be processed

### DIFF
--- a/application/pages/modplatform/ftb/FtbListModel.cpp
+++ b/application/pages/modplatform/ftb/FtbListModel.cpp
@@ -106,21 +106,22 @@ void ListModel::getLogo(const QString &logo, const QString &logoUrl, LogoCallbac
 
 void ListModel::searchWithTerm(const QString &term)
 {
-    if(currentSearchTerm == term && currentSearchTerm.isNull() == term.isNull()) {
+    if(searchState != Failed && currentSearchTerm == term && currentSearchTerm.isNull() == term.isNull()) {
+        // unless the search has failed, then there is no need to perform an identical search.
         return;
     }
     currentSearchTerm = term;
+
     if(jobPtr) {
         jobPtr->abort();
-        searchState = ResetRequested;
-        return;
+        jobPtr.reset();
     }
-    else {
-        beginResetModel();
-        modpacks.clear();
-        endResetModel();
-        searchState = None;
-    }
+
+    beginResetModel();
+    modpacks.clear();
+    endResetModel();
+    searchState = None;
+
     performSearch();
 }
 
@@ -154,15 +155,7 @@ void ListModel::searchRequestFailed(QString reason)
     jobPtr.reset();
     remainingPacks.clear();
 
-    if(searchState == ResetRequested) {
-        beginResetModel();
-        modpacks.clear();
-        endResetModel();
-
-        performSearch();
-    } else {
-        searchState = Finished;
-    }
+    searchState = Failed;
 }
 
 void ListModel::requestPack()

--- a/application/pages/modplatform/ftb/FtbListModel.h
+++ b/application/pages/modplatform/ftb/FtbListModel.h
@@ -57,7 +57,8 @@ private:
         None,
         CanPossiblyFetchMore,
         ResetRequested,
-        Finished
+        Finished,
+        Failed,
     } searchState = None;
     NetJobPtr jobPtr;
     int currentPack;


### PR DESCRIPTION
This resolves an issue with the modpacks.ch search functionality, in
which a search issued while one is currently in progress won't be made
and the UI won't allow for the search to be made after.

Reproduction Steps:
1. Open the FTB pane in the Add Instance Dialog
2. Perform a search while MMC is still performing the initial search

The search won't be performed, the existing search will have been
aborted, and you are unable to try the search again (without trying a
different search in the meantime).

This was caused by 2 things:
1. A search cannot be re-attempted, and this logic doesn't consider
   failures.
2. The failure slot wasn't called when the NetJob was aborted, so
   the search would never be performed - but the term would be
   stored as if it had (trigering point 1).

I have resolved this by doing 2 things:
1. If the failure slot is called, set a searchState of Failed. Allow
   search re-attempts in this case.
2. If there is a present NetJob, abort and reset it. The immediately
   continue with the search.
