### PR TITLE
Add ability to select a server to join in the instance settings

### DIFF
--- a/api/logic/BaseInstance.h
+++ b/api/logic/BaseInstance.h
@@ -147,7 +147,8 @@ public:
     virtual shared_qobject_ptr<Task> createUpdateTask(Net::Mode mode) = 0;
 
     /// returns a valid launcher (task container)
-    virtual shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account) = 0;
+    virtual shared_qobject_ptr<LaunchTask> createLaunchTask(
+            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) = 0;
 
     /// returns the current launch task (if any)
     shared_qobject_ptr<LaunchTask> getLaunchTask();

--- a/api/logic/BaseInstance.h
+++ b/api/logic/BaseInstance.h
@@ -34,6 +34,8 @@
 
 #include "multimc_logic_export.h"
 
+#include "minecraft/launch/MinecraftServerTarget.h"
+
 class QDir;
 class Task;
 class LaunchTask;
@@ -221,9 +223,9 @@ public:
     bool reloadSettings();
 
     /**
-     * 'print' a verbose desription of the instance into a QStringList
+     * 'print' a verbose description of the instance into a QStringList
      */
-    virtual QStringList verboseDescription(AuthSessionPtr session) = 0;
+    virtual QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) = 0;
 
     Status currentStatus() const;
 

--- a/api/logic/CMakeLists.txt
+++ b/api/logic/CMakeLists.txt
@@ -238,6 +238,7 @@ set(MINECRAFT_SOURCES
     minecraft/launch/ExtractNatives.h
     minecraft/launch/LauncherPartLaunch.cpp
     minecraft/launch/LauncherPartLaunch.h
+    minecraft/launch/MinecraftServerTarget.cpp
     minecraft/launch/MinecraftServerTarget.h
     minecraft/launch/PrintInstanceInfo.cpp
     minecraft/launch/PrintInstanceInfo.h

--- a/api/logic/CMakeLists.txt
+++ b/api/logic/CMakeLists.txt
@@ -124,6 +124,8 @@ set(NET_SOURCES
 
 # Game launch logic
 set(LAUNCH_SOURCES
+    launch/steps/LookupServerAddress.cpp
+    launch/steps/LookupServerAddress.h
     launch/steps/PostLaunchCommand.cpp
     launch/steps/PostLaunchCommand.h
     launch/steps/PreLaunchCommand.cpp
@@ -236,6 +238,7 @@ set(MINECRAFT_SOURCES
     minecraft/launch/ExtractNatives.h
     minecraft/launch/LauncherPartLaunch.cpp
     minecraft/launch/LauncherPartLaunch.h
+    minecraft/launch/MinecraftServerTarget.h
     minecraft/launch/PrintInstanceInfo.cpp
     minecraft/launch/PrintInstanceInfo.h
     minecraft/launch/ReconstructAssets.cpp

--- a/api/logic/NullInstance.h
+++ b/api/logic/NullInstance.h
@@ -67,7 +67,7 @@ public:
     {
         return false;
     }
-    QStringList verboseDescription(AuthSessionPtr session) override
+    QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override
     {
         QStringList out;
         out << "Null instance - placeholder.";

--- a/api/logic/NullInstance.h
+++ b/api/logic/NullInstance.h
@@ -27,7 +27,7 @@ public:
     {
         return instanceRoot();
     };
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr) override
+    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr, MinecraftServerTargetPtr) override
     {
         return nullptr;
     }

--- a/api/logic/launch/steps/LookupServerAddress.cpp
+++ b/api/logic/launch/steps/LookupServerAddress.cpp
@@ -1,3 +1,19 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 #include "LookupServerAddress.h"
 
 #include <launch/LaunchTask.h>

--- a/api/logic/launch/steps/LookupServerAddress.cpp
+++ b/api/logic/launch/steps/LookupServerAddress.cpp
@@ -16,11 +16,6 @@ void LookupServerAddress::setLookupAddress(const QString &lookupAddress)
     m_dnsLookup->setName(QString("_minecraft._tcp.%1").arg(lookupAddress));
 }
 
-void LookupServerAddress::setPort(quint16 port)
-{
-    m_port = port;
-}
-
 void LookupServerAddress::setOutputAddressPtr(MinecraftServerTargetPtr output)
 {
     m_output = std::move(output);
@@ -50,7 +45,7 @@ void LookupServerAddress::on_dnsLookupFinished()
     {
         emit logLine(QString("Failed to resolve server address (this is NOT an error!) %1: %2\n")
             .arg(m_dnsLookup->name(), m_dnsLookup->errorString()), MessageLevel::MultiMC);
-        resolve(m_lookupAddress, m_port); // Technically the task failed, however, we don't abort the launch
+        resolve(m_lookupAddress, 25565); // Technically the task failed, however, we don't abort the launch
                                                       // and leave it up to minecraft to fail (or maybe not) when connecting
         return;
     }
@@ -61,28 +56,17 @@ void LookupServerAddress::on_dnsLookupFinished()
         emit logLine(
                 QString("Failed to resolve server address %1: the DNS lookup succeeded, but no records were returned.\n")
                 .arg(m_dnsLookup->name()), MessageLevel::Warning);
-        resolve(m_lookupAddress, m_port); // Technically the task failed, however, we don't abort the launch
+        resolve(m_lookupAddress, 25565); // Technically the task failed, however, we don't abort the launch
                                                       // and leave it up to minecraft to fail (or maybe not) when connecting
         return;
     }
 
     const auto &firstRecord = records.at(0);
-
-    if (firstRecord.port() != m_port && m_port != 0)
-    {
-        emit logLine(
-                QString("DNS record for %1 suggested %2 as server port, but user supplied %3. Using user override,"
-                        " but the port may be wrong!\n").arg(m_dnsLookup->name(), QString::number(firstRecord.port()), QString::number(m_port)),
-                        MessageLevel::Warning);
-    }
-    else if (m_port == 0)
-    {
-        m_port = firstRecord.port();
-    }
+    quint16 port = firstRecord.port();
 
     emit logLine(QString("Resolved server address %1 to %2 with port %3\n").arg(
-            m_dnsLookup->name(), firstRecord.target(), QString::number(m_port)),MessageLevel::MultiMC);
-    resolve(firstRecord.target(), m_port);
+            m_dnsLookup->name(), firstRecord.target(), QString::number(port)),MessageLevel::MultiMC);
+    resolve(firstRecord.target(), port);
 }
 
 void LookupServerAddress::resolve(const QString &address, quint16 port)

--- a/api/logic/launch/steps/LookupServerAddress.cpp
+++ b/api/logic/launch/steps/LookupServerAddress.cpp
@@ -1,0 +1,95 @@
+#include "LookupServerAddress.h"
+
+#include <launch/LaunchTask.h>
+
+LookupServerAddress::LookupServerAddress(LaunchTask *parent) :
+    LaunchStep(parent), m_dnsLookup(new QDnsLookup(this))
+{
+    connect(m_dnsLookup, &QDnsLookup::finished, this, &LookupServerAddress::on_dnsLookupFinished);
+
+    m_dnsLookup->setType(QDnsLookup::SRV);
+}
+
+void LookupServerAddress::setLookupAddress(const QString &lookupAddress)
+{
+    m_lookupAddress = lookupAddress;
+    m_dnsLookup->setName(QString("_minecraft._tcp.%1").arg(lookupAddress));
+}
+
+void LookupServerAddress::setPort(quint16 port)
+{
+    m_port = port;
+}
+
+void LookupServerAddress::setOutputAddressPtr(MinecraftServerTargetPtr output)
+{
+    m_output = std::move(output);
+}
+
+bool LookupServerAddress::abort()
+{
+    m_dnsLookup->abort();
+    emitFailed("Aborted");
+    return true;
+}
+
+void LookupServerAddress::executeTask()
+{
+    m_dnsLookup->lookup();
+}
+
+void LookupServerAddress::on_dnsLookupFinished()
+{
+    if (isFinished())
+    {
+        // Aborted
+        return;
+    }
+
+    if (m_dnsLookup->error() != QDnsLookup::NoError)
+    {
+        emit logLine(QString("Failed to resolve server address (this is NOT an error!) %1: %2\n")
+            .arg(m_dnsLookup->name(), m_dnsLookup->errorString()), MessageLevel::MultiMC);
+        resolve(m_lookupAddress, m_port); // Technically the task failed, however, we don't abort the launch
+                                                      // and leave it up to minecraft to fail (or maybe not) when connecting
+        return;
+    }
+
+    const auto records = m_dnsLookup->serviceRecords();
+    if (records.empty())
+    {
+        emit logLine(
+                QString("Failed to resolve server address %1: the DNS lookup succeeded, but no records were returned.\n")
+                .arg(m_dnsLookup->name()), MessageLevel::Warning);
+        resolve(m_lookupAddress, m_port); // Technically the task failed, however, we don't abort the launch
+                                                      // and leave it up to minecraft to fail (or maybe not) when connecting
+        return;
+    }
+
+    const auto &firstRecord = records.at(0);
+
+    if (firstRecord.port() != m_port && m_port != 0)
+    {
+        emit logLine(
+                QString("DNS record for %1 suggested %2 as server port, but user supplied %3. Using user override,"
+                        " but the port may be wrong!\n").arg(m_dnsLookup->name(), QString::number(firstRecord.port()), QString::number(m_port)),
+                        MessageLevel::Warning);
+    }
+    else if (m_port == 0)
+    {
+        m_port = firstRecord.port();
+    }
+
+    emit logLine(QString("Resolved server address %1 to %2 with port %3\n").arg(
+            m_dnsLookup->name(), firstRecord.target(), QString::number(m_port)),MessageLevel::MultiMC);
+    resolve(firstRecord.target(), m_port);
+}
+
+void LookupServerAddress::resolve(const QString &address, quint16 port)
+{
+    m_output->address = address;
+    m_output->port = port;
+
+    emitSucceeded();
+    m_dnsLookup->deleteLater();
+}

--- a/api/logic/launch/steps/LookupServerAddress.h
+++ b/api/logic/launch/steps/LookupServerAddress.h
@@ -16,43 +16,36 @@
 #pragma once
 
 #include <launch/LaunchStep.h>
-#include <LoggedProcess.h>
-#include <minecraft/auth/AuthSession.h>
+#include <QObjectPtr.h>
+#include <QDnsLookup>
 
-#include "MinecraftServerTarget.h"
+#include "minecraft/launch/MinecraftServerTarget.h"
 
-class DirectJavaLaunch: public LaunchStep
-{
-    Q_OBJECT
+class LookupServerAddress: public LaunchStep {
+Q_OBJECT
 public:
-    explicit DirectJavaLaunch(LaunchTask *parent);
-    virtual ~DirectJavaLaunch() {};
+    explicit LookupServerAddress(LaunchTask *parent);
+    virtual ~LookupServerAddress() {};
 
     virtual void executeTask();
     virtual bool abort();
-    virtual void proceed();
     virtual bool canAbort() const
     {
         return true;
     }
-    void setWorkingDirectory(const QString &wd);
-    void setAuthSession(AuthSessionPtr session)
-    {
-        m_session = session;
-    }
 
-    void setServerToJoin(MinecraftServerTargetPtr serverToJoin)
-    {
-        m_serverToJoin = std::move(serverToJoin);
-    }
+    void setLookupAddress(const QString &lookupAddress);
+    void setPort(quint16 port);
+    void setOutputAddressPtr(MinecraftServerTargetPtr output);
 
 private slots:
-    void on_state(LoggedProcess::State state);
+    void on_dnsLookupFinished();
 
 private:
-    LoggedProcess m_process;
-    QString m_command;
-    AuthSessionPtr m_session;
-    MinecraftServerTargetPtr m_serverToJoin;
-};
+    void resolve(const QString &address, quint16 port);
 
+    QDnsLookup *m_dnsLookup;
+    QString m_lookupAddress;
+    quint16 m_port;
+    MinecraftServerTargetPtr m_output;
+};

--- a/api/logic/launch/steps/LookupServerAddress.h
+++ b/api/logic/launch/steps/LookupServerAddress.h
@@ -35,7 +35,6 @@ public:
     }
 
     void setLookupAddress(const QString &lookupAddress);
-    void setPort(quint16 port);
     void setOutputAddressPtr(MinecraftServerTargetPtr output);
 
 private slots:
@@ -46,6 +45,5 @@ private:
 
     QDnsLookup *m_dnsLookup;
     QString m_lookupAddress;
-    quint16 m_port;
     MinecraftServerTargetPtr m_output;
 };

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -859,12 +859,20 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
 
     if (m_settings->get("JoinServerOnLaunch").toBool())
     {
-        // Resolve server address to join on launch
-        auto *step = new LookupServerAddress(pptr);
-        step->setLookupAddress(m_settings->get("JoinServerOnLaunchAddress").toString());
-        step->setPort(m_settings->get("JoinServerOnLaunchPort").toInt());
-        step->setOutputAddressPtr(serverToJoin);
-        process->appendStep(step);
+        quint16 port = m_settings->get("JoinServerOnLaunchPort").toInt();
+        QString address = m_settings->get("JoinServerOnLaunchAddress").toString();
+
+        serverToJoin->port = port;
+        serverToJoin->address = address;
+
+        if(port == 25565)
+        {
+            // Resolve server address to join on launch
+            auto *step = new LookupServerAddress(pptr);
+            step->setLookupAddress(address);
+            step->setOutputAddressPtr(serverToJoin);
+            process->appendStep(step);
+        }
     }
 
     // run pre-launch command if that's needed

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -409,6 +409,12 @@ QStringList MinecraftInstance::processMinecraftArgs(AuthSessionPtr session) cons
         args_pattern += " --tweakClass " + tweaker;
     }
 
+    if (m_settings->get("JoinServerOnLaunch").toBool())
+    {
+        args_pattern += " --server " + m_settings->get("JoinServerOnLaunchAddress").toString();
+        args_pattern += " --port " + m_settings->get("JoinServerOnLaunchPort").toString();
+    }
+
     QMap<QString, QString> token_mapping;
     // yggdrasil!
     if(session)

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -474,8 +474,17 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftS
         launchScript += "appletClass " + appletClass + "\n";
     }
 
+    if (serverToJoin && !serverToJoin->address.isEmpty())
+    {
+        launchScript += "serverAddress " + serverToJoin->address + "\n";
+        launchScript += "serverPort " + QString::number(serverToJoin->port) + "\n";
+    }
+
     // generic minecraft params
-    for (auto param : processMinecraftArgs(session, serverToJoin))
+    for (auto param : processMinecraftArgs(
+            session,
+            nullptr /* When using a launch script, the server parameters are handled by it*/
+    ))
     {
         launchScript += "param " + param + "\n";
     }

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -111,6 +111,11 @@ MinecraftInstance::MinecraftInstance(SettingsObjectPtr globalSettings, SettingsO
     m_settings->registerOverride(globalSettings->getSetting("ShowGameTime"), gameTimeOverride);
     m_settings->registerOverride(globalSettings->getSetting("RecordGameTime"), gameTimeOverride);
 
+    // Join server on launch, this does not have a global override
+    m_settings->registerSetting("JoinServerOnLaunch", false);
+    m_settings->registerSetting("JoinServerOnLaunchAddress", "");
+    m_settings->registerSetting("JoinServerOnLaunchPort", 25565);
+
     // DEPRECATED: Read what versions the user configuration thinks should be used
     m_settings->registerSetting({"IntendedVersion", "MinecraftVersion"}, "");
     m_settings->registerSetting("LWJGLVersion", "");

--- a/api/logic/minecraft/MinecraftInstance.h
+++ b/api/logic/minecraft/MinecraftInstance.h
@@ -5,6 +5,7 @@
 #include <QProcess>
 #include <QDir>
 #include "multimc_logic_export.h"
+#include "minecraft/launch/MinecraftServerTarget.h"
 
 class ModFolderModel;
 class WorldList;
@@ -78,9 +79,9 @@ public:
     shared_qobject_ptr<Task> createUpdateTask(Net::Mode mode) override;
     shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account) override;
     QStringList extraArguments() const override;
-    QStringList verboseDescription(AuthSessionPtr session) override;
+    QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
     QList<Mod> getJarMods() const;
-    QString createLaunchScript(AuthSessionPtr session);
+    QString createLaunchScript(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin);
     /// get arguments passed to java
     QStringList javaArguments() const;
 
@@ -107,7 +108,7 @@ public:
     virtual QString getMainClass() const;
 
     // FIXME: remove
-    virtual QStringList processMinecraftArgs(AuthSessionPtr account) const;
+    virtual QStringList processMinecraftArgs(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) const;
 
     virtual JavaVersion getJavaVersion() const;
 

--- a/api/logic/minecraft/MinecraftInstance.h
+++ b/api/logic/minecraft/MinecraftInstance.h
@@ -77,7 +77,7 @@ public:
 
     //////  Launch stuff //////
     shared_qobject_ptr<Task> createUpdateTask(Net::Mode mode) override;
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account) override;
+    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override;
     QStringList extraArguments() const override;
     QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
     QList<Mod> getJarMods() const;

--- a/api/logic/minecraft/launch/DirectJavaLaunch.cpp
+++ b/api/logic/minecraft/launch/DirectJavaLaunch.cpp
@@ -55,7 +55,7 @@ void DirectJavaLaunch::executeTask()
     // make detachable - this will keep the process running even if the object is destroyed
     m_process.setDetachable(true);
 
-    auto mcArgs = minecraftInstance->processMinecraftArgs(m_session);
+    auto mcArgs = minecraftInstance->processMinecraftArgs(m_session, m_serverToJoin);
     args.append(mcArgs);
 
     QString wrapperCommandStr = instance->getWrapperCommand().trimmed();

--- a/api/logic/minecraft/launch/LauncherPartLaunch.cpp
+++ b/api/logic/minecraft/launch/LauncherPartLaunch.cpp
@@ -59,7 +59,7 @@ void LauncherPartLaunch::executeTask()
     auto instance = m_parent->instance();
     std::shared_ptr<MinecraftInstance> minecraftInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
 
-    m_launchScript = minecraftInstance->createLaunchScript(m_session);
+    m_launchScript = minecraftInstance->createLaunchScript(m_session, m_serverToJoin);
     QStringList args = minecraftInstance->javaArguments();
     QString allArgs = args.join(", ");
     emit logLine("Java Arguments:\n[" + m_parent->censorPrivateInfo(allArgs) + "]\n\n", MessageLevel::MultiMC);

--- a/api/logic/minecraft/launch/LauncherPartLaunch.h
+++ b/api/logic/minecraft/launch/LauncherPartLaunch.h
@@ -19,6 +19,8 @@
 #include <LoggedProcess.h>
 #include <minecraft/auth/AuthSession.h>
 
+#include "MinecraftServerTarget.h"
+
 class LauncherPartLaunch: public LaunchStep
 {
     Q_OBJECT
@@ -39,6 +41,11 @@ public:
         m_session = session;
     }
 
+    void setServerToJoin(MinecraftServerTargetPtr serverToJoin)
+    {
+        m_serverToJoin = std::move(serverToJoin);
+    }
+
 private slots:
     void on_state(LoggedProcess::State state);
 
@@ -47,5 +54,7 @@ private:
     QString m_command;
     AuthSessionPtr m_session;
     QString m_launchScript;
+    MinecraftServerTargetPtr m_serverToJoin;
+
     bool mayProceed = false;
 };

--- a/api/logic/minecraft/launch/MinecraftServerTarget.cpp
+++ b/api/logic/minecraft/launch/MinecraftServerTarget.cpp
@@ -1,0 +1,66 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MinecraftServerTarget.h"
+
+#include <QStringList>
+
+MinecraftServerTarget MinecraftServerTarget::parse(const QString &fullAddress) {
+    QStringList split = fullAddress.split(":");
+
+    // The logic below replicates the exact logic minecraft uses for parsing server addresses.
+    // While the conversion is not lossless and eats errors, it ensures the same behavior
+    // within Minecraft and MultiMC when entering server addresses.
+    if (fullAddress.startsWith("["))
+    {
+        int bracket = fullAddress.indexOf("]");
+        if (bracket > 0)
+        {
+            QString ipv6 = fullAddress.mid(1, bracket - 1);
+            QString port = fullAddress.mid(bracket + 1).trimmed();
+
+            if (port.startsWith(":") && !ipv6.isEmpty())
+            {
+                port = port.mid(1);
+                split = QStringList({ ipv6, port });
+            }
+            else
+            {
+                split = QStringList({ipv6});
+            }
+        }
+    }
+
+    if (split.size() > 2)
+    {
+        split = QStringList({fullAddress});
+    }
+
+    QString realAddress = split[0];
+
+    quint16 realPort = 25565;
+    if (split.size() > 1)
+    {
+        bool ok;
+        realPort = split[1].toUInt(&ok);
+
+        if (!ok)
+        {
+            realPort = 25565;
+        }
+    }
+
+    return MinecraftServerTarget { realAddress, realPort };
+}

--- a/api/logic/minecraft/launch/MinecraftServerTarget.h
+++ b/api/logic/minecraft/launch/MinecraftServerTarget.h
@@ -1,0 +1,25 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+struct MinecraftServerTarget {
+    QString address;
+    quint16 port;
+};
+
+typedef std::shared_ptr<MinecraftServerTarget> MinecraftServerTargetPtr;

--- a/api/logic/minecraft/launch/MinecraftServerTarget.h
+++ b/api/logic/minecraft/launch/MinecraftServerTarget.h
@@ -17,9 +17,14 @@
 
 #include <memory>
 
+#include <QString>
+#include <multimc_logic_export.h>
+
 struct MinecraftServerTarget {
     QString address;
     quint16 port;
+
+    static MULTIMC_LOGIC_EXPORT MinecraftServerTarget parse(const QString &fullAddress);
 };
 
 typedef std::shared_ptr<MinecraftServerTarget> MinecraftServerTargetPtr;

--- a/api/logic/minecraft/launch/PrintInstanceInfo.cpp
+++ b/api/logic/minecraft/launch/PrintInstanceInfo.cpp
@@ -101,6 +101,6 @@ void PrintInstanceInfo::executeTask()
 #endif
 
     logLines(log, MessageLevel::MultiMC);
-    logLines(instance->verboseDescription(m_session), MessageLevel::MultiMC);
+    logLines(instance->verboseDescription(m_session, m_serverToJoin), MessageLevel::MultiMC);
     emitSucceeded();
 }

--- a/api/logic/minecraft/launch/PrintInstanceInfo.h
+++ b/api/logic/minecraft/launch/PrintInstanceInfo.h
@@ -18,13 +18,15 @@
 #include <launch/LaunchStep.h>
 #include <memory>
 #include "minecraft/auth/AuthSession.h"
+#include "minecraft/launch/MinecraftServerTarget.h"
 
 // FIXME: temporary wrapper for existing task.
 class PrintInstanceInfo: public LaunchStep
 {
     Q_OBJECT
 public:
-    explicit PrintInstanceInfo(LaunchTask *parent, AuthSessionPtr session) : LaunchStep(parent), m_session(session) {};
+    explicit PrintInstanceInfo(LaunchTask *parent, AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) :
+        LaunchStep(parent), m_session(session), m_serverToJoin(serverToJoin) {};
     virtual ~PrintInstanceInfo(){};
 
     virtual void executeTask();
@@ -34,5 +36,6 @@ public:
     }
 private:
     AuthSessionPtr m_session;
+    MinecraftServerTargetPtr m_serverToJoin;
 };
 

--- a/api/logic/minecraft/legacy/LegacyInstance.cpp
+++ b/api/logic/minecraft/legacy/LegacyInstance.cpp
@@ -225,7 +225,7 @@ QString LegacyInstance::getStatusbarDescription()
     return tr("Instance from previous versions.");
 }
 
-QStringList LegacyInstance::verboseDescription(AuthSessionPtr session)
+QStringList LegacyInstance::verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin)
 {
     QStringList out;
 

--- a/api/logic/minecraft/legacy/LegacyInstance.h
+++ b/api/logic/minecraft/legacy/LegacyInstance.h
@@ -125,7 +125,7 @@ public:
     }
 
     QString getStatusbarDescription() override;
-    QStringList verboseDescription(AuthSessionPtr session) override;
+    QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
 
     QProcessEnvironment createEnvironment() override
     {

--- a/api/logic/minecraft/legacy/LegacyInstance.h
+++ b/api/logic/minecraft/legacy/LegacyInstance.h
@@ -111,7 +111,8 @@ public:
     {
         return false;
     }
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account) override
+    shared_qobject_ptr<LaunchTask> createLaunchTask(
+            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override
     {
         return nullptr;
     }

--- a/application/InstancePageProvider.h
+++ b/application/InstancePageProvider.h
@@ -46,7 +46,7 @@ public:
             values.append(new TexturePackPage(onesix.get()));
             values.append(new NotesPage(onesix.get()));
             values.append(new WorldListPage(onesix.get(), onesix->worldList()));
-            values.append(new ServersPage(onesix.get()));
+            values.append(new ServersPage(onesix));
             // values.append(new GameOptionsPage(onesix.get()));
             values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
             values.append(new InstanceSettingsPage(onesix.get()));

--- a/application/LaunchController.cpp
+++ b/application/LaunchController.cpp
@@ -197,7 +197,7 @@ void LaunchController::launchInstance()
         return;
     }
 
-    m_launcher = m_instance->createLaunchTask(m_session);
+    m_launcher = m_instance->createLaunchTask(m_session, m_serverToJoin);
     if (!m_launcher)
     {
         emitFailed(tr("Couldn't instantiate a launcher."));

--- a/application/LaunchController.h
+++ b/application/LaunchController.h
@@ -3,6 +3,8 @@
 #include <BaseInstance.h>
 #include <tools/BaseProfiler.h>
 
+#include "minecraft/launch/MinecraftServerTarget.h"
+
 class InstanceWindow;
 class LaunchController: public Task
 {
@@ -33,6 +35,10 @@ public:
     {
         m_parentWidget = widget;
     }
+    void setServerToJoin(MinecraftServerTargetPtr serverToJoin)
+    {
+        m_serverToJoin = std::move(serverToJoin);
+    }
     QString id()
     {
         return m_instance->id();
@@ -58,4 +64,5 @@ private:
     InstanceWindow *m_console = nullptr;
     AuthSessionPtr m_session;
     shared_qobject_ptr<LaunchTask> m_launcher;
+    MinecraftServerTargetPtr m_serverToJoin;
 };

--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -1014,8 +1014,12 @@ bool MultiMC::openJsonEditor(const QString &filename)
     }
 }
 
-bool MultiMC::launch(InstancePtr instance, bool online, BaseProfilerFactory *profiler)
-{
+bool MultiMC::launch(
+        InstancePtr instance,
+        bool online,
+        BaseProfilerFactory *profiler,
+        MinecraftServerTargetPtr serverToJoin
+) {
     if(m_updateRunning)
     {
         qDebug() << "Cannot launch instances while an update is running. Please try again when updates are completed.";
@@ -1036,6 +1040,7 @@ bool MultiMC::launch(InstancePtr instance, bool online, BaseProfilerFactory *pro
         controller->setInstance(instance);
         controller->setOnline(online);
         controller->setProfiler(profiler);
+        controller->setServerToJoin(serverToJoin);
         if(window)
         {
             controller->setParentWidget(window);

--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -191,6 +191,11 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         parser.addOption("launch");
         parser.addShortOpt("launch", 'l');
         parser.addDocumentation("launch", "Launch the specified instance (by instance ID)");
+        // --server
+        parser.addOption("server");
+        parser.addShortOpt("server", 's');
+        parser.addDocumentation("server", "Join the specified server on launch "
+                                          "(only valid in combination with --launch)");
         // --alive
         parser.addSwitch("alive");
         parser.addDocumentation("alive", "Write a small '" + liveCheckFile + "' file after MultiMC starts");
@@ -232,6 +237,7 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         }
     }
     m_instanceIdToLaunch = args["launch"].toString();
+    m_serverToJoin = args["server"].toString();
     m_liveCheck = args["alive"].toBool();
     m_zipToImport = args["import"].toUrl();
 
@@ -293,6 +299,13 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         return;
     }
 
+    if(m_instanceIdToLaunch.isEmpty() && !m_serverToJoin.isEmpty())
+    {
+        std::cerr << "--server can only be used in combination with --launch!" << std::endl;
+        m_status = MultiMC::Failed;
+        return;
+    }
+
     /*
      * Establish the mechanism for communication with an already running MultiMC that uses the same data path.
      * If there is one, tell it what the user actually wanted to do and exit.
@@ -318,7 +331,15 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
             }
             else
             {
-                m_peerInstance->sendMessage("launch " + m_instanceIdToLaunch, timeout);
+                if(!m_serverToJoin.isEmpty())
+                {
+                    m_peerInstance->sendMessage(
+                            "launch-with-server " + m_instanceIdToLaunch + " " + m_serverToJoin, timeout);
+                }
+                else
+                {
+                    m_peerInstance->sendMessage("launch " + m_instanceIdToLaunch, timeout);
+                }
             }
             m_status = MultiMC::Succeeded;
             return;
@@ -398,6 +419,10 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
         if(!m_instanceIdToLaunch.isEmpty())
         {
             qDebug() << "ID of instance to launch   : " << m_instanceIdToLaunch;
+        }
+        if(!m_serverToJoin.isEmpty())
+        {
+            qDebug() << "Address of server to join  :" << m_serverToJoin;
         }
         qDebug() << "<> Paths set.";
     }
@@ -844,8 +869,19 @@ void MultiMC::performMainStartupAction()
         auto inst = instances()->getInstanceById(m_instanceIdToLaunch);
         if(inst)
         {
-            qDebug() << "<> Instance launching:" << m_instanceIdToLaunch;
-            launch(inst, true, nullptr);
+            MinecraftServerTargetPtr serverToJoin = nullptr;
+
+            if(!m_serverToJoin.isEmpty())
+            {
+                serverToJoin.reset(new MinecraftServerTarget(MinecraftServerTarget::parse(m_serverToJoin)));
+                qDebug() << "<> Instance" << m_instanceIdToLaunch << "launching with server" << m_serverToJoin;
+            }
+            else
+            {
+                qDebug() << "<> Instance" << m_instanceIdToLaunch << "launching";
+            }
+
+            launch(inst, true, nullptr, serverToJoin);
             return;
         }
     }
@@ -925,6 +961,31 @@ void MultiMC::messageReceived(const QString& message)
         if(inst)
         {
             launch(inst, true, nullptr);
+        }
+    }
+    else if(command == "launch-with-server")
+    {
+        QString instanceID = message.section(' ', 1, 1);
+        QString serverToJoin = message.section(' ', 2, 2);
+        if(instanceID.isEmpty())
+        {
+            qWarning() << "Received" << command << "message without an instance ID.";
+            return;
+        }
+        if(serverToJoin.isEmpty())
+        {
+            qWarning() << "Received" << command << "message without a server to join.";
+            return;
+        }
+        auto inst = instances()->getInstanceById(instanceID);
+        if(inst)
+        {
+            launch(
+                    inst,
+                    true,
+                    nullptr,
+                    std::make_shared<MinecraftServerTarget>(MinecraftServerTarget::parse(serverToJoin))
+            );
         }
     }
     else

--- a/application/MultiMC.h
+++ b/application/MultiMC.h
@@ -11,6 +11,8 @@
 
 #include <BaseInstance.h>
 
+#include "minecraft/launch/MinecraftServerTarget.h"
+
 class LaunchController;
 class LocalPeer;
 class InstanceWindow;
@@ -150,7 +152,12 @@ signals:
     void globalSettingsClosed();
 
 public slots:
-    bool launch(InstancePtr instance, bool online = true, BaseProfilerFactory *profiler = nullptr);
+    bool launch(
+            InstancePtr instance,
+            bool online = true,
+            BaseProfilerFactory *profiler = nullptr,
+            MinecraftServerTargetPtr serverToJoin = nullptr
+    );
     bool kill(InstancePtr instance);
 
 private slots:

--- a/application/MultiMC.h
+++ b/application/MultiMC.h
@@ -228,6 +228,7 @@ private:
     SetupWizard * m_setupWizard = nullptr;
 public:
     QString m_instanceIdToLaunch;
+    QString m_serverToJoin;
     bool m_liveCheck = false;
     QUrl m_zipToImport;
     std::unique_ptr<QFile> logFile;

--- a/application/pages/instance/InstanceSettingsPage.cpp
+++ b/application/pages/instance/InstanceSettingsPage.cpp
@@ -198,12 +198,10 @@ void InstanceSettingsPage::applySettings()
     if (joinServerOnLaunch)
     {
         m_settings->set("JoinServerOnLaunchAddress", ui->serverJoinAddress->text());
-        m_settings->set("JoinServerOnLaunchPort", ui->serverJoinPort->value());
     }
     else
     {
         m_settings->reset("JoinServerOnLaunchAddress");
-        m_settings->reset("JoinServerOnLaunchPort");
     }
 }
 
@@ -274,7 +272,6 @@ void InstanceSettingsPage::loadSettings()
 
     ui->serverJoinGroupBox->setChecked(m_settings->get("JoinServerOnLaunch").toBool());
     ui->serverJoinAddress->setText(m_settings->get("JoinServerOnLaunchAddress").toString());
-    ui->serverJoinPort->setValue(m_settings->get("JoinServerOnLaunchPort").toInt());
 }
 
 void InstanceSettingsPage::on_javaDetectBtn_clicked()

--- a/application/pages/instance/InstanceSettingsPage.cpp
+++ b/application/pages/instance/InstanceSettingsPage.cpp
@@ -191,6 +191,20 @@ void InstanceSettingsPage::applySettings()
         m_settings->reset("ShowGameTime");
         m_settings->reset("RecordGameTime");
     }
+
+    // Join server on launch
+    bool joinServerOnLaunch = ui->serverJoinGroupBox->isChecked();
+    m_settings->set("JoinServerOnLaunch", joinServerOnLaunch);
+    if (joinServerOnLaunch)
+    {
+        m_settings->set("JoinServerOnLaunchAddress", ui->serverJoinAddress->text());
+        m_settings->set("JoinServerOnLaunchPort", ui->serverJoinPort->value());
+    }
+    else
+    {
+        m_settings->reset("JoinServerOnLaunchAddress");
+        m_settings->reset("JoinServerOnLaunchPort");
+    }
 }
 
 void InstanceSettingsPage::loadSettings()
@@ -257,6 +271,10 @@ void InstanceSettingsPage::loadSettings()
     ui->gameTimeGroupBox->setChecked(m_settings->get("OverrideGameTime").toBool());
     ui->showGameTime->setChecked(m_settings->get("ShowGameTime").toBool());
     ui->recordGameTime->setChecked(m_settings->get("RecordGameTime").toBool());
+
+    ui->serverJoinGroupBox->setChecked(m_settings->get("JoinServerOnLaunch").toBool());
+    ui->serverJoinAddress->setText(m_settings->get("JoinServerOnLaunchAddress").toString());
+    ui->serverJoinPort->setValue(m_settings->get("JoinServerOnLaunchPort").toInt());
 }
 
 void InstanceSettingsPage::on_javaDetectBtn_clicked()

--- a/application/pages/instance/InstanceSettingsPage.ui
+++ b/application/pages/instance/InstanceSettingsPage.ui
@@ -39,7 +39,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="minecraftTab">
       <attribute name="title">
@@ -449,6 +449,58 @@
              <string>Record time spent playing this instance</string>
             </property>
            </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="serverJoinGroupBox">
+         <property name="title">
+          <string>Set a server to join on launch</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_11">
+          <item>
+           <layout class="QGridLayout" name="serverJoinLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="serverJoinAddressLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Server address:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="serverJoinAddress"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="serverJoinPortLabel">
+              <property name="text">
+               <string>Server port:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="serverJoinPort">
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+              <property name="value">
+               <number>25565</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/application/pages/instance/InstanceSettingsPage.ui
+++ b/application/pages/instance/InstanceSettingsPage.ui
@@ -39,7 +39,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="minecraftTab">
       <attribute name="title">
@@ -482,23 +482,6 @@
             </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="serverJoinAddress"/>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="serverJoinPortLabel">
-              <property name="text">
-               <string>Server port:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="serverJoinPort">
-              <property name="maximum">
-               <number>65535</number>
-              </property>
-              <property name="value">
-               <number>25565</number>
-              </property>
-             </widget>
             </item>
            </layout>
           </item>

--- a/application/pages/instance/InstanceSettingsPage.ui
+++ b/application/pages/instance/InstanceSettingsPage.ui
@@ -39,7 +39,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="minecraftTab">
       <attribute name="title">

--- a/application/pages/instance/ServersPage.cpp
+++ b/application/pages/instance/ServersPage.cpp
@@ -556,7 +556,7 @@ private:
     QTimer m_saveTimer;
 };
 
-ServersPage::ServersPage(MinecraftInstance * inst, QWidget* parent)
+ServersPage::ServersPage(InstancePtr inst, QWidget* parent)
     : QMainWindow(parent), ui(new Ui::ServersPage)
 {
     ui->setupUi(this);
@@ -579,7 +579,7 @@ ServersPage::ServersPage(MinecraftInstance * inst, QWidget* parent)
 
     auto selectionModel = ui->serversView->selectionModel();
     connect(selectionModel, &QItemSelectionModel::currentChanged, this, &ServersPage::currentChanged);
-    connect(m_inst, &MinecraftInstance::runningStatusChanged, this, &ServersPage::on_RunningState_changed);
+    connect(m_inst.get(), &MinecraftInstance::runningStatusChanged, this, &ServersPage::on_RunningState_changed);
     connect(ui->nameLine, &QLineEdit::textEdited, this, &ServersPage::nameEdited);
     connect(ui->addressLine, &QLineEdit::textEdited, this, &ServersPage::addressEdited);
     connect(ui->resourceComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(resourceIndexChanged(int)));
@@ -695,6 +695,7 @@ void ServersPage::updateState()
     ui->actionMove_Down->setEnabled(serverEditEnabled);
     ui->actionMove_Up->setEnabled(serverEditEnabled);
     ui->actionRemove->setEnabled(serverEditEnabled);
+    ui->actionJoin->setEnabled(serverEditEnabled);
 
     if(server)
     {
@@ -756,6 +757,12 @@ void ServersPage::on_actionMove_Down_triggered()
     {
         currentServer ++;
     }
+}
+
+void ServersPage::on_actionJoin_triggered()
+{
+    const auto &address = m_model->at(currentServer)->m_address;
+    MMC->launch(m_inst, true, nullptr, std::make_shared<MinecraftServerTarget>(MinecraftServerTarget::parse(address)));
 }
 
 #include "ServersPage.moc"

--- a/application/pages/instance/ServersPage.h
+++ b/application/pages/instance/ServersPage.h
@@ -35,7 +35,7 @@ class ServersPage : public QMainWindow, public BasePage
     Q_OBJECT
 
 public:
-    explicit ServersPage(MinecraftInstance *inst, QWidget *parent = 0);
+    explicit ServersPage(InstancePtr inst, QWidget *parent = 0);
     virtual ~ServersPage();
 
     void openedImpl() override;
@@ -74,6 +74,7 @@ private slots:
     void on_actionRemove_triggered();
     void on_actionMove_Up_triggered();
     void on_actionMove_Down_triggered();
+    void on_actionJoin_triggered();
 
     void on_RunningState_changed(bool running);
 
@@ -88,6 +89,6 @@ private: // data
     bool m_locked = true;
     Ui::ServersPage *ui = nullptr;
     ServersModel * m_model = nullptr;
-    MinecraftInstance * m_inst = nullptr;
+    InstancePtr m_inst = nullptr;
 };
 

--- a/application/pages/instance/ServersPage.ui
+++ b/application/pages/instance/ServersPage.ui
@@ -148,6 +148,7 @@
    <addaction name="actionRemove"/>
    <addaction name="actionMove_Up"/>
    <addaction name="actionMove_Down"/>
+   <addaction name="actionJoin"/>
   </widget>
   <action name="actionAdd">
    <property name="text">
@@ -167,6 +168,11 @@
   <action name="actionMove_Down">
    <property name="text">
     <string>Move Down</string>
+   </property>
+  </action>
+  <action name="actionJoin">
+   <property name="text">
+    <string>Join</string>
    </property>
   </action>
  </widget>

--- a/libraries/launcher/org/multimc/LegacyFrame.java
+++ b/libraries/launcher/org/multimc/LegacyFrame.java
@@ -46,7 +46,16 @@ public class LegacyFrame extends Frame implements WindowListener
         this.addWindowListener ( this );
     }
 
-    public void start ( Applet mcApplet, String user, String session, int winSizeW, int winSizeH, boolean maximize )
+    public void start (
+        Applet mcApplet,
+        String user,
+        String session,
+        int winSizeW,
+        int winSizeH,
+        boolean maximize,
+        String serverAddress,
+        String serverPort
+    )
     {
         try {
             appletWrap = new Launcher( mcApplet, new URL ( "http://www.minecraft.net/game" ) );
@@ -95,6 +104,13 @@ public class LegacyFrame extends Frame implements WindowListener
             e.printStackTrace(System.err);
             System.exit(-1);
         }
+
+        if (serverAddress != null)
+        {
+            appletWrap.setParameter("server", serverAddress);
+            appletWrap.setParameter("port", serverPort);
+        }
+
         appletWrap.setParameter ( "username", user );
         appletWrap.setParameter ( "sessionid", session );
         appletWrap.setParameter ( "stand-alone", "true" ); // Show the quit button.

--- a/libraries/launcher/org/multimc/onesix/OneSixLauncher.java
+++ b/libraries/launcher/org/multimc/onesix/OneSixLauncher.java
@@ -47,6 +47,9 @@ public class OneSixLauncher implements Launcher
     private boolean maximize;
     private String cwd;
 
+    private String serverAddress;
+    private String serverPort;
+
     // the much abused system classloader, for convenience (for further abuse)
     private ClassLoader cl;
 
@@ -63,6 +66,9 @@ public class OneSixLauncher implements Launcher
         sessionId = params.first("sessionId");
         windowTitle = params.firstSafe("windowTitle", "Minecraft");
         windowParams = params.firstSafe("windowParams", "854x480");
+
+        serverAddress = params.firstSafe("serverAddress", null);
+        serverPort = params.firstSafe("serverPort", null);
 
         cwd = System.getProperty("user.dir");
 
@@ -122,7 +128,7 @@ public class OneSixLauncher implements Launcher
                 Class<?> MCAppletClass = cl.loadClass(appletClass);
                 Applet mcappl = (Applet) MCAppletClass.newInstance();
                 LegacyFrame mcWindow = new LegacyFrame(windowTitle);
-                mcWindow.start(mcappl, userName, sessionId, winSizeW, winSizeH, maximize);
+                mcWindow.start(mcappl, userName, sessionId, winSizeW, winSizeH, maximize, serverAddress, serverPort);
                 return 0;
             } catch (Exception e)
             {
@@ -162,6 +168,14 @@ public class OneSixLauncher implements Launcher
             mcparams.add(Integer.toString(winSizeW));
             mcparams.add("--height");
             mcparams.add(Integer.toString(winSizeH));
+        }
+
+        if (serverAddress != null)
+        {
+            mcparams.add("--server");
+            mcparams.add(serverAddress);
+            mcparams.add("--port");
+            mcparams.add(serverPort);
         }
 
         // Get the Minecraft Class.


### PR DESCRIPTION
This PR allows to set a server in the instance settings. Additionally it performs DNS lookup using the pattern `_minecraft._tcp.<server address>`, since Minecraft skips this step when using `--server` and `--port`.

I confirmed this to be working from Minecraft 1.0 up to the current version. Older version might work as well, given that they accept the required arguments using the applet wrapper.

Ref:
![image](https://user-images.githubusercontent.com/25827180/119230278-cba48500-bb1b-11eb-84ef-7bff9e414acd.png)
