### PR TITLE
NOISSUE Flagged mods system

### DIFF
--- a/api/logic/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/api/logic/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -9,8 +9,9 @@
 
 namespace ModpacksCH {
 
-PackInstallTask::PackInstallTask(Modpack pack, QString version)
+PackInstallTask::PackInstallTask(UserInteractionSupport *support, Modpack pack, QString version)
 {
+    m_support = support;
     m_pack = pack;
     m_version_name = version;
 }
@@ -173,6 +174,59 @@ void PackInstallTask::install()
     instance.setName(m_instName);
     instance.setIconKey(m_instIcon);
     instanceSettings->resumeSave();
+
+    // flag certain mods
+    QDir modsDir(FS::PathCombine(m_stagingPath, "minecraft", "mods"));
+    if (modsDir.exists()) {
+        QVector<ModpacksCH::FlaggedMod> flaggedMods;
+
+        for (const auto& info : modsDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Files)) {
+            // FTB Auxilium
+            if (info.fileName().startsWith("ftbauxilium") && info.fileName().endsWith(".jar")) {
+                flaggedMods.append(ModpacksCH::FlaggedMod {
+                    info.absoluteFilePath(),
+                    "FTB Auxilium",
+                    tr("Sends system information, crash reports, and when you join/quit singleplayer or multiplayer sessions to FTB's servers."),
+                    tr("Tracking")
+                });
+            }
+
+            // MCMC
+            if (info.fileName().startsWith("mcmc") && info.fileName().endsWith(".jar")) {
+                flaggedMods.append(ModpacksCH::FlaggedMod {
+                    info.absoluteFilePath(),
+                    "MCMC",
+                    tr("Sends system information, crash reports, and when you join/quit singleplayer or multiplayer sessions to MCMC's servers."),
+                    tr("Tracking")
+                });
+            }
+
+            // MineTogether
+            if (info.fileName().startsWith("minetogether") && info.fileName().endsWith(".jar")) {
+                flaggedMods.append(ModpacksCH::FlaggedMod {
+                    info.absoluteFilePath(),
+                    "MineTogether",
+                    tr("Provides global game chat, and advertises CreeperHost services in the multiplayer screen."),
+                    tr("Advertising")
+                });
+            }
+
+            // SimpleDiscordRichPresence
+            if (info.fileName().startsWith("SimpleDiscordRichPresence") && info.fileName().endsWith(".jar")) {
+                flaggedMods.append(ModpacksCH::FlaggedMod {
+                    info.absoluteFilePath(),
+                    "SimpleDiscordRichPresence",
+                    tr("Shares game state with Discord, if installed."),
+                    tr("Tracking")
+                });
+            }
+        }
+
+        qInfo() << "Flagged" << flaggedMods.size() << "mods";
+        if (!flaggedMods.isEmpty()) {
+            m_support->showFlaggedModsDialog(flaggedMods);
+        }
+    }
 
     emitSucceeded();
 }

--- a/api/logic/modplatform/modpacksch/FTBPackInstallTask.h
+++ b/api/logic/modplatform/modpacksch/FTBPackInstallTask.h
@@ -8,12 +8,39 @@
 
 namespace ModpacksCH {
 
+struct MULTIMC_LOGIC_EXPORT FlaggedMod {
+    QString fileName;
+
+    /**
+     * The name of the mod.
+     */
+    QString modName;
+    /**
+     * A description of the mod's purpose, and why a user may want to enable the mod.
+     */
+    QString modDescription;
+
+    /**
+     * The reason the mod was flagged, this should be plain-and-simple.
+     * <p>
+     * Examples may include: 'Tracking' or 'Advertising'
+     */
+    QString flagReason;
+};
+
+class MULTIMC_LOGIC_EXPORT UserInteractionSupport {
+
+public:
+    virtual void showFlaggedModsDialog(QVector<FlaggedMod> mods) = 0;
+
+};
+
 class MULTIMC_LOGIC_EXPORT PackInstallTask : public InstanceTask
 {
     Q_OBJECT
 
 public:
-    explicit PackInstallTask(Modpack pack, QString version);
+    explicit PackInstallTask(UserInteractionSupport *support, Modpack pack, QString version);
     virtual ~PackInstallTask(){}
 
     bool abort() override;
@@ -30,6 +57,8 @@ private:
     void install();
 
 private:
+    UserInteractionSupport *m_support;
+
     NetJobPtr jobPtr;
     QByteArray response;
 

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -134,6 +134,10 @@ SET(MULTIMC_SOURCES
 
     pages/modplatform/ftb/FtbFilterModel.cpp
     pages/modplatform/ftb/FtbFilterModel.h
+    pages/modplatform/ftb/FtbFlaggedModsDialog.cpp
+    pages/modplatform/ftb/FtbFlaggedModsDialog.h
+    pages/modplatform/ftb/FtbFlaggedModsListModel.cpp
+    pages/modplatform/ftb/FtbFlaggedModsListModel.h
     pages/modplatform/ftb/FtbListModel.cpp
     pages/modplatform/ftb/FtbListModel.h
     pages/modplatform/ftb/FtbPage.cpp
@@ -292,6 +296,9 @@ SET(MULTIMC_UIS
     dialogs/UpdateDialog.ui
     dialogs/NotificationDialog.ui
     dialogs/SkinUploadDialog.ui
+
+    # Platform Dialogs
+    pages/modplatform/ftb/FtbFlaggedModsDialog.ui
 
     # Widgets/other
     widgets/CustomCommands.ui

--- a/application/pages/modplatform/ftb/FtbFlaggedModsDialog.cpp
+++ b/application/pages/modplatform/ftb/FtbFlaggedModsDialog.cpp
@@ -1,0 +1,20 @@
+#include "FtbFlaggedModsDialog.h"
+#include "ui_FtbFlaggedModsDialog.h"
+
+#include "FtbFlaggedModsListModel.h"
+
+FtbFlaggedModsDialog::FtbFlaggedModsDialog(QWidget *parent, QVector<ModpacksCH::FlaggedMod> mods)
+    : QDialog(parent), ui(new Ui::FtbFlaggedModsDialog)
+{
+    ui->setupUi(this);
+
+    listModel = new FlaggedModsListModel(this, mods);
+
+    ui->modTreeView->setModel(listModel);
+
+    connect(this, &FtbFlaggedModsDialog::finished, listModel, &FlaggedModsListModel::enableDisableMods);
+}
+
+FtbFlaggedModsDialog::~FtbFlaggedModsDialog() {
+    delete ui;
+}

--- a/application/pages/modplatform/ftb/FtbFlaggedModsDialog.h
+++ b/application/pages/modplatform/ftb/FtbFlaggedModsDialog.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QDialog>
+#include "FtbFlaggedModsListModel.h"
+
+namespace Ui
+{
+class FtbFlaggedModsDialog;
+}
+
+class FtbFlaggedModsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FtbFlaggedModsDialog(QWidget *parent, QVector<ModpacksCH::FlaggedMod> mods);
+    ~FtbFlaggedModsDialog() override;
+
+private:
+    Ui::FtbFlaggedModsDialog *ui;
+
+    FlaggedModsListModel *listModel;
+
+};

--- a/application/pages/modplatform/ftb/FtbFlaggedModsDialog.ui
+++ b/application/pages/modplatform/ftb/FtbFlaggedModsDialog.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FtbFlaggedModsDialog</class>
+ <widget class="QDialog" name="FtbFlaggedModsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>597</width>
+    <height>353</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Flagged Mods Selection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>The following mods have been identified by MultiMC as being used for the purposes of tracking, advertising, or similar. MultiMC believes that you should be given a choice on whether to enable these mods.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>These mods are disabled by default, you may override this below individually for each mod. These mods can later be enabled through the 'Loader Mods' settings page.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="ModListView" name="modTreeView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::DropOnly</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ModListView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/ModListView.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FtbFlaggedModsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FtbFlaggedModsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/application/pages/modplatform/ftb/FtbFlaggedModsListModel.cpp
+++ b/application/pages/modplatform/ftb/FtbFlaggedModsListModel.cpp
@@ -1,0 +1,95 @@
+#include "FtbFlaggedModsListModel.h"
+
+FlaggedModsListModel::FlaggedModsListModel(QWidget *parent, QVector<ModpacksCH::FlaggedMod> flaggedMods)
+    : QAbstractListModel(parent), m_flaggedMods(flaggedMods)
+{
+    // fill in defaults
+    for (const auto& mod : flaggedMods) {
+        m_modState[mod.fileName] = false;
+    }
+}
+
+int FlaggedModsListModel::rowCount(const QModelIndex &parent) const {
+    return m_flaggedMods.size();
+}
+
+int FlaggedModsListModel::columnCount(const QModelIndex &parent) const {
+    // enable/disable, name, flag reason, description
+    return 4;
+}
+
+QVariant FlaggedModsListModel::data(const QModelIndex &index, int role) const {
+    auto row = index.row();
+    auto mod = m_flaggedMods.at(row);
+
+    if (index.column() == EnabledColumn && role == Qt::CheckStateRole) {
+        return m_modState[mod.fileName] ? Qt::Checked : Qt::Unchecked;
+    }
+
+    if (role == Qt::DisplayRole) {
+        if (index.column() == FlaggedForColumn) {
+            return mod.flagReason;
+        }
+        if (index.column() == NameColumn) {
+            return mod.modName;
+        }
+        if (index.column() == DescriptionColumn) {
+            return mod.modDescription;
+        }
+    }
+
+    return QVariant();
+}
+
+bool FlaggedModsListModel::setData(const QModelIndex &index, const QVariant &value, int role) {
+    if (role == Qt::CheckStateRole) {
+        auto row = index.row();
+        auto mod = m_flaggedMods.at(row);
+
+        // toggle the state
+        m_modState[mod.fileName] = !m_modState[mod.fileName];
+
+        emit dataChanged(FlaggedModsListModel::index(row, 0),
+                         FlaggedModsListModel::index(row, columnCount(QModelIndex()) - 1));
+        return true;
+    }
+
+    return false;
+}
+
+QVariant FlaggedModsListModel::headerData(int section, Qt::Orientation orientation, int role) const {
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {
+        switch (section) {
+            case EnabledColumn:
+                return QString();
+            case FlaggedForColumn:
+                return QString("Flag Reason");
+            case NameColumn:
+                return QString("Name");
+            case DescriptionColumn:
+                return QString("Description");
+        }
+    }
+
+    return QVariant();
+}
+
+void FlaggedModsListModel::enableDisableMods() {
+    for (const auto& mod : m_flaggedMods) {
+        if (!m_modState[mod.fileName]) {
+            // Disable the mod by appending .disabled to filename
+            QFile file(mod.fileName);
+            if (!file.rename(mod.fileName + ".disabled")) {
+                qWarning() << "Failed to disable" << mod.fileName;
+            }
+        }
+    }
+}
+
+Qt::ItemFlags FlaggedModsListModel::flags(const QModelIndex &index) const {
+    auto flags = QAbstractListModel::flags(index);
+    if (index.isValid()) {
+        flags |= Qt::ItemIsUserCheckable;
+    }
+    return flags;
+}

--- a/application/pages/modplatform/ftb/FtbFlaggedModsListModel.h
+++ b/application/pages/modplatform/ftb/FtbFlaggedModsListModel.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QAbstractListModel>
+#include "FtbPage.h"
+
+class FlaggedModsListModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum Columns
+    {
+        EnabledColumn = 0,
+        NameColumn,
+        FlaggedForColumn,
+        DescriptionColumn,
+    };
+
+    FlaggedModsListModel(QWidget *parent, QVector<ModpacksCH::FlaggedMod> flaggedMods);
+
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+
+    QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+public slots:
+    void enableDisableMods();
+
+private:
+    QVector<ModpacksCH::FlaggedMod> m_flaggedMods;
+    QMap<QString, bool> m_modState;
+
+};

--- a/application/pages/modplatform/ftb/FtbPage.cpp
+++ b/application/pages/modplatform/ftb/FtbPage.cpp
@@ -7,6 +7,7 @@
 #include "modplatform/modpacksch/FTBPackInstallTask.h"
 
 #include "HoeDown.h"
+#include "FtbFlaggedModsDialog.h"
 
 FtbPage::FtbPage(NewInstanceDialog* dialog, QWidget *parent)
         : QWidget(parent), ui(new Ui::FtbPage), dialog(dialog)
@@ -68,7 +69,7 @@ void FtbPage::suggestCurrent()
 {
     if(isOpened)
     {
-        dialog->setSuggestedPack(selected.name, new ModpacksCH::PackInstallTask(selected, selectedVersion));
+        dialog->setSuggestedPack(selected.name, new ModpacksCH::PackInstallTask(this, selected, selectedVersion));
 
         for(auto art : selected.art) {
             if(art.type == "square") {
@@ -132,4 +133,9 @@ void FtbPage::onVersionSelectionChanged(QString data)
 
     selectedVersion = data;
     suggestCurrent();
+}
+
+void FtbPage::showFlaggedModsDialog(QVector<ModpacksCH::FlaggedMod> mods) {
+    FtbFlaggedModsDialog flagDialog(this, mods);
+    flagDialog.exec();
 }

--- a/application/pages/modplatform/ftb/FtbPage.h
+++ b/application/pages/modplatform/ftb/FtbPage.h
@@ -19,6 +19,7 @@
 #include "FtbListModel.h"
 
 #include <QWidget>
+#include <modplatform/modpacksch/FTBPackInstallTask.h>
 
 #include "MultiMC.h"
 #include "pages/BasePage.h"
@@ -31,7 +32,7 @@ namespace Ui
 
 class NewInstanceDialog;
 
-class FtbPage : public QWidget, public BasePage
+class FtbPage : public QWidget, public BasePage, public ModpacksCH::UserInteractionSupport
 {
 Q_OBJECT
 
@@ -62,6 +63,8 @@ public:
 
 private:
     void suggestCurrent();
+
+    void showFlaggedModsDialog(QVector<ModpacksCH::FlaggedMod> mods) override;
 
 private slots:
     void triggerSearch();


### PR DESCRIPTION
This pull request introduces a post-installation dialog for getting user consent to have certain mods ('flagged mods') be enabled. At present this intends to cover mods for Tracking and Advertising purposes, and is limited to the modpacks.ch support - but should be rolled out to other platforms with time.

This pull request will disable any flagged mods that have not been explicitly allowed by the user, using the standard MultiMC disable mechanism - note that any disabled mods can always be enabled at a later date (through Instance Settings -> Loader Mods).

![image](https://user-images.githubusercontent.com/5103549/119268912-f01c6200-bbec-11eb-857c-12e11c55e88c.png)

The above is an example dialog from FTB Cotton 1.0.0 where FTB Auxilium has been explictly enabled.