### PR TITLE
Fix setup wizzard says no Java regardless

### DIFF
--- a/application/setupwizard/JavaWizardPage.cpp
+++ b/application/setupwizard/JavaWizardPage.cpp
@@ -90,7 +90,6 @@ bool JavaWizardPage::validatePage()
 void JavaWizardPage::retranslate()
 {
     setTitle(tr("Java"));
-    setSubTitle(tr("You do not have a working Java set up yet or it went missing.\n"
-        "Please select one of the following or browse for a java executable."));
+    setSubTitle(tr("Please select one of the following or browse for a java executable."));
     m_java_widget->retranslate();
 }


### PR DESCRIPTION
Hi everyone,

I noticed that the setup wizard always says "You do not have a working Java set up yet or it went missing"  even if the person does have Java installed. I have removed it.

Thanks!