### PR TITLE
NOISSUE Specify support URLs at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,15 @@ set(MultiMC_PASTE_EE_API_KEY "utLvciUouSURFzfjPxLBf5W4ISsUX4pwBDF7N1AfZ" CACHE S
 # Google analytics ID
 set(MultiMC_ANALYTICS_ID "UA-87731965-2" CACHE STRING "ID you can get from Google analytics")
 
+# Bug tracker URL
+set(MultiMC_BUG_TRACKER_URL "" CACHE STRING "URL for the bug tracker.")
+
+# Discord URL
+set(MultiMC_DISCORD_URL "" CACHE STRING "URL for the Discord guild.")
+
+# Subreddit URL
+set(MultiMC_SUBREDDIT_URL "" CACHE STRING "URL for the subreddit.")
+
 #### Check the current Git commit and branch
 include(GetGitRevisionDescription)
 get_git_head_revision(MultiMC_GIT_REFSPEC MultiMC_GIT_COMMIT)

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -306,29 +306,35 @@ public:
         helpMenu = new QMenu(MainWindow);
         helpMenu->setToolTipsVisible(true);
 
-        actionReportBug = TranslatedAction(MainWindow);
-        actionReportBug->setObjectName(QStringLiteral("actionReportBug"));
-        actionReportBug->setIcon(MMC->getThemedIcon("bug"));
-        actionReportBug.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Report a Bug"));
-        actionReportBug.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open the bug tracker to report a bug with MultiMC."));
-        all_actions.append(&actionReportBug);
-        helpMenu->addAction(actionReportBug);
+        if (!BuildConfig.BUG_TRACKER_URL.isEmpty()) {
+            actionReportBug = TranslatedAction(MainWindow);
+            actionReportBug->setObjectName(QStringLiteral("actionReportBug"));
+            actionReportBug->setIcon(MMC->getThemedIcon("bug"));
+            actionReportBug.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Report a Bug"));
+            actionReportBug.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open the bug tracker to report a bug with MultiMC."));
+            all_actions.append(&actionReportBug);
+            helpMenu->addAction(actionReportBug);
+        }
 
-        actionDISCORD = TranslatedAction(MainWindow);
-        actionDISCORD->setObjectName(QStringLiteral("actionDISCORD"));
-        actionDISCORD->setIcon(MMC->getThemedIcon("discord"));
-        actionDISCORD.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Discord"));
-        actionDISCORD.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open MultiMC discord voice chat."));
-        all_actions.append(&actionDISCORD);
-        helpMenu->addAction(actionDISCORD);
+        if (!BuildConfig.DISCORD_URL.isEmpty()) {
+            actionDISCORD = TranslatedAction(MainWindow);
+            actionDISCORD->setObjectName(QStringLiteral("actionDISCORD"));
+            actionDISCORD->setIcon(MMC->getThemedIcon("discord"));
+            actionDISCORD.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Discord"));
+            actionDISCORD.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open MultiMC discord voice chat."));
+            all_actions.append(&actionDISCORD);
+            helpMenu->addAction(actionDISCORD);
+        }
 
-        actionREDDIT = TranslatedAction(MainWindow);
-        actionREDDIT->setObjectName(QStringLiteral("actionREDDIT"));
-        actionREDDIT->setIcon(MMC->getThemedIcon("reddit-alien"));
-        actionREDDIT.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Reddit"));
-        actionREDDIT.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open MultiMC subreddit."));
-        all_actions.append(&actionREDDIT);
-        helpMenu->addAction(actionREDDIT);
+        if (!BuildConfig.SUBREDDIT_URL.isEmpty()) {
+            actionREDDIT = TranslatedAction(MainWindow);
+            actionREDDIT->setObjectName(QStringLiteral("actionREDDIT"));
+            actionREDDIT->setIcon(MMC->getThemedIcon("reddit-alien"));
+            actionREDDIT.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Reddit"));
+            actionREDDIT.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open MultiMC subreddit."));
+            all_actions.append(&actionREDDIT);
+            helpMenu->addAction(actionREDDIT);
+        }
 
         actionAbout = TranslatedAction(MainWindow);
         actionAbout->setObjectName(QStringLiteral("actionAbout"));
@@ -1455,12 +1461,12 @@ void MainWindow::droppedURLs(QList<QUrl> urls)
 
 void MainWindow::on_actionREDDIT_triggered()
 {
-    DesktopServices::openUrl(QUrl("https://www.reddit.com/r/MultiMC/"));
+    DesktopServices::openUrl(QUrl(BuildConfig.SUBREDDIT_URL));
 }
 
 void MainWindow::on_actionDISCORD_triggered()
 {
-    DesktopServices::openUrl(QUrl("https://discord.gg/multimc"));
+    DesktopServices::openUrl(QUrl(BuildConfig.DISCORD_URL));
 }
 
 void MainWindow::on_actionChangeInstIcon_triggered()
@@ -1638,7 +1644,7 @@ void MainWindow::on_actionManageAccounts_triggered()
 
 void MainWindow::on_actionReportBug_triggered()
 {
-    DesktopServices::openUrl(QUrl("https://github.com/MultiMC/MultiMC5/issues"));
+    DesktopServices::openUrl(QUrl(BuildConfig.BUG_TRACKER_URL));
 }
 
 void MainWindow::on_actionPatreon_triggered()

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -34,6 +34,10 @@ Config::Config()
     NEWS_RSS_URL = "@MultiMC_NEWS_RSS_URL@";
     PASTE_EE_KEY = "@MultiMC_PASTE_EE_API_KEY@";
     META_URL = "@MultiMC_META_URL@";
+
+    BUG_TRACKER_URL = "@MultiMC_BUG_TRACKER_URL@";
+    DISCORD_URL = "@MultiMC_DISCORD_URL@";
+    SUBREDDIT_URL = "@MultiMC_SUBREDDIT_URL@";
 }
 
 QString Config::printableVersionString() const

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -65,6 +65,10 @@ public:
      */
     QString META_URL;
 
+    QString BUG_TRACKER_URL;
+    QString DISCORD_URL;
+    QString SUBREDDIT_URL;
+
     QString RESOURCE_BASE = "https://resources.download.minecraft.net/";
     QString LIBRARY_BASE = "https://libraries.minecraft.net/";
     QString SKINS_BASE = "https://crafatar.com/skins/";


### PR DESCRIPTION
Support URLs (bug tracker, Discord guild, subreddit) are now specified
as cache variables in cmake, and the buttons are not shown if no value
is set for them.

This is an early-stage move towards debranding the MultiMC codebase,
and will (hopefully) alleviate support requests coming to us from
illicit forks.
