### PR TITLE
NOISSUE Fix ATLauncher version selection combo box width

### DIFF
--- a/application/pages/modplatform/atlauncher/AtlPage.ui
+++ b/application/pages/modplatform/atlauncher/AtlPage.ui
@@ -51,14 +51,7 @@
    <item row="2" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,0,0" rowminimumheight="0" columnminimumwidth="0,0,0">
      <item row="0" column="2">
-      <widget class="QComboBox" name="versionSelectionBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="versionSelectionBox"/>
      </item>
      <item row="0" column="1">
       <widget class="QLabel" name="label">


### PR DESCRIPTION
Resolves a bug that was introduced with [1], furthermore and in
specific relation to the intent of said commit, this brings the
version selection combo box inline with other mod platforms.

[1] f7c144c3932a18e1cd96e1ad7505e53ea706a47d
