### PR TITLE
[Linux] Add detection of manually installed JDKs in /opt

### DIFF
--- a/api/logic/java/JavaUtils.cpp
+++ b/api/logic/java/JavaUtils.cpp
@@ -381,6 +381,9 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDir("/usr/lib32/jvm");
     // javas stored in MultiMC's folder
     scanJavaDir("java");
+    // manually installed JDKs in /opt
+    scanJavaDir("/opt/jdk");
+    scanJavaDir("/opt/jdks");
     return javas;
 }
 #else


### PR DESCRIPTION
I have several versions of AdoptOpenJDK that I manually installed in /opt/jdk/. It was bugging me that those installs weren't auto-detected by MultiMC, so I added a couple lines to make it scan there.
### Before
![image](https://user-images.githubusercontent.com/46203390/122969678-88277b80-d352-11eb-98a1-728da8560711.png)

### After
![image](https://user-images.githubusercontent.com/46203390/122969836-bd33ce00-d352-11eb-80f9-5d66377f22ad.png)
