### PR TITLE
NOISSUE: Rename Minecraft Log to Instance Log

### DIFF
--- a/application/pages/instance/LogPage.h
+++ b/application/pages/instance/LogPage.h
@@ -38,7 +38,7 @@ public:
     virtual ~LogPage();
     virtual QString displayName() const override
     {
-        return tr("Minecraft Log");
+        return tr("Instance Log");
     }
     virtual QIcon icon() const override
     {


### PR DESCRIPTION
Renaming it, to avoid possible confusion with the actual minecraft logs, and more accurately describe what its true being is.