### PR TITLE
Stop application freezes on macOS by moving data to MultiMC.app/Data

### DIFF
--- a/application/pages/global/MultiMCPage.cpp
+++ b/application/pages/global/MultiMCPage.cpp
@@ -29,6 +29,9 @@
 #include "BuildConfig.h"
 #include "themes/ITheme.h"
 
+#include <QApplication>
+#include <QProcess>
+
 // FIXME: possibly move elsewhere
 enum InstSortMode
 {
@@ -78,6 +81,13 @@ MultiMCPage::MultiMCPage(QWidget *parent) : QWidget(parent), ui(new Ui::MultiMCP
     }
     connect(ui->fontSizeBox, SIGNAL(valueChanged(int)), SLOT(refreshFontPreview()));
     connect(ui->consoleFont, SIGNAL(currentFontChanged(QFont)), SLOT(refreshFontPreview()));
+
+    //move mac data button
+    QFile file(QDir::current().absolutePath() + "/dontmovemacdata");
+    if (!file.exists())
+    {
+        ui->migrateDataFolderMacBtn->setVisible(false);
+    }
 }
 
 MultiMCPage::~MultiMCPage()
@@ -145,6 +155,13 @@ void MultiMCPage::on_modsDirBrowseBtn_clicked()
         QString cooked_dir = FS::NormalizePath(raw_dir);
         ui->modsDirTextBox->setText(cooked_dir);
     }
+}
+void MultiMCPage::on_migrateDataFolderMacBtn_clicked()
+{
+    QFile file(QDir::current().absolutePath() + "/dontmovemacdata");
+    file.remove();
+    QProcess::startDetached(qApp->arguments()[0]);
+    qApp->quit();
 }
 
 void MultiMCPage::refreshUpdateChannelList()

--- a/application/pages/global/MultiMCPage.h
+++ b/application/pages/global/MultiMCPage.h
@@ -67,6 +67,7 @@ slots:
     void on_instDirBrowseBtn_clicked();
     void on_modsDirBrowseBtn_clicked();
     void on_iconsDirBrowseBtn_clicked();
+    void on_migrateDataFolderMacBtn_clicked();
 
     /*!
      * Updates the list of update channels in the combo box.

--- a/application/pages/global/MultiMCPage.ui
+++ b/application/pages/global/MultiMCPage.ui
@@ -158,6 +158,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="migrateDataFolderMacBtn">
+         <property name="text">
+          <string>Move MultiMC data to new location (will restart MultiMC)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Fixes #3081
Fixes #2529
This is a continuation of PR #3081 which has a dialogue on the first launch that asks the user if they want to move and explains some of the benefits and drawbacks. It also adds a button in the settings menu that allows the user to move the data at a later date if they say no initially. If a user selects no, the dialogue doesn't show up again and they can change their option with the setting. There is no way to move the data back through an interface, but the user could move contents of `MultiMC.app/Data` to `MultiMC.app/Contents/MacOS`. On the initial launch, it chooses the new location by default, without prompt.
No translations have been added at the moment because I do not know how to add them.