### PR TITLE
NOISSUE Disable Install Forge button on 1.17 (and above)

### DIFF
--- a/api/logic/minecraft/OneSixVersionFormat.cpp
+++ b/api/logic/minecraft/OneSixVersionFormat.cpp
@@ -194,8 +194,7 @@ VersionFilePtr OneSixVersionFormat::versionFileFromJson(const QJsonDocument &doc
             LibDLInfo->artifact = out->mojangDownloads["client"];
             lib->setMojangDownloadInfo(LibDLInfo);
         }
-        // we got nothing... guess based on ancient hardcoded Mojang behaviour
-        // FIXME: this will eventually break...
+        // we got nothing...
         else
         {
             out->addProblem(

--- a/application/pages/instance/VersionPage.cpp
+++ b/application/pages/instance/VersionPage.cpp
@@ -212,12 +212,16 @@ void VersionPage::updateVersionControls()
 {
     // FIXME: this is a dirty hack
     auto minecraftVersion = Version(m_profile->getComponentVersion("net.minecraft"));
-    bool newCraft = minecraftVersion >= Version("1.14");
-    bool oldCraft = minecraftVersion <= Version("1.12.2");
-    ui->actionInstall_Fabric->setEnabled(controlsEnabled && newCraft);
-    ui->actionInstall_Forge->setEnabled(controlsEnabled);
-    ui->actionInstall_LiteLoader->setEnabled(controlsEnabled && oldCraft);
-    ui->actionReload->setEnabled(true);
+
+    bool supportsFabric = minecraftVersion >= Version("1.14");
+    ui->actionInstall_Fabric->setEnabled(controlsEnabled && supportsFabric);
+
+    bool supportsForge = minecraftVersion <= Version("1.16.5");
+    ui->actionInstall_Forge->setEnabled(controlsEnabled && supportsForge);
+
+    bool supportsLiteLoader = minecraftVersion <= Version("1.12.2");
+    ui->actionInstall_LiteLoader->setEnabled(controlsEnabled && supportsLiteLoader);
+
     updateButtons();
 }
 


### PR DESCRIPTION
It appears that Minecraft Forge for Minecraft 1.17 will require setting
JVM arguments to operate, this is not currently possible with MultiMC's
meta.

Therefore, when Forge for 1.17 is released a solution will need to be
looked into.
