### PR TITLE
fix: lin-system layout

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -882,7 +882,7 @@ qt5_wrap_ui(MULTIMC_UI ${MULTIMC_UIS})
 qt5_add_resources(MULTIMC_RESOURCES ${MULTIMC_QRCS})
 
 # Add executable
-add_library(MultiMC_logic STATIC ${LOGIC_SOURCES} ${MULTIMC_SOURCES} ${MULTIMC_UI} ${MULTIMC_RESOURCES})
+add_library(MultiMC_logic STATIC ${LOGIC_SOURCES})
 target_link_libraries(MultiMC_logic
     systeminfo
     MultiMC_quazip
@@ -909,7 +909,7 @@ target_link_libraries(MultiMC_logic
     ganalytics
 )
 
-add_executable(MultiMC MACOSX_BUNDLE WIN32 main.cpp ${MULTIMC_RCS})
+add_executable(MultiMC MACOSX_BUNDLE WIN32 main.cpp ${MULTIMC_SOURCES} ${MULTIMC_UI} ${MULTIMC_RESOURCES} ${MULTIMC_RCS})
 target_link_libraries(MultiMC MultiMC_logic)
 
 if(DEFINED MultiMC_APP_BINARY_NAME)


### PR DESCRIPTION
Properly propagate LINUX_DATA_DIR

I use `multimc-git` from AUR. 20b9f2b42a3b58b6081af271774fbcc34025dccb broke this in two ways.

1) Resources such as the logo moved.
2) `lin-system` layout mode stopped using the XDG_DATA_DIR by default.

This commit addresses the second issue.