### PR TITLE
Add flat icon for custom-commands

### DIFF
--- a/launcher/resources/flat/flat.qrc
+++ b/launcher/resources/flat/flat.qrc
@@ -10,6 +10,7 @@
         <file>scalable/checkupdate.svg</file>
         <file>scalable/copy.svg</file>
         <file>scalable/coremods.svg</file>
+        <file>scalable/custom-commands.svg</file>
         <file>scalable/discord.svg</file>
         <file>scalable/externaltools.svg</file>
         <file>scalable/help.svg</file>

--- a/launcher/resources/flat/scalable/custom-commands.svg
+++ b/launcher/resources/flat/scalable/custom-commands.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   fill="#757575"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="custom-commands.svg"
+   inkscape:version="1.1 (c4e8f9ed74, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3440"
+     inkscape:window-height="1382"
+     id="namedview6"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="39.333333"
+     inkscape:cx="11.38983"
+     inkscape:cy="13.283898"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid981" />
+    <sodipodi:guide
+       position="-8,11.440678"
+       orientation="1,0"
+       id="guide1060"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-28.34375,24"
+       orientation="0,1"
+       id="guide1062"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <g
+     style="fill:#000000"
+     id="g821"
+     transform="matrix(0.0322459,0,0,0.0322459,-17.878956,30.647558)">
+    <g
+       style="fill:#000000"
+       id="g819" />
+  </g>
+  <g
+     id="g503">
+    <path
+       d="M 0,0 H 24 V 24 H 0 Z"
+       fill="none"
+       id="path491" />
+    <path
+       d="M 8.7,15.9 4.8,12 8.7,8.1 C 9.09,7.71 9.09,7.09 8.7,6.7 8.31,6.31 7.69,6.31 7.3,6.7 l -4.59,4.59 c -0.39,0.39 -0.39,1.02 0,1.41 l 4.59,4.6 c 0.39,0.39 1.01,0.39 1.4,0 0.39,-0.39 0.39,-1.01 0,-1.4 z m 6.6,0 3.9,-3.9 -3.9,-3.9 c -0.39,-0.39 -0.39,-1.01 0,-1.4 0.39,-0.39 1.01,-0.39 1.4,0 l 4.59,4.59 c 0.39,0.39 0.39,1.02 0,1.41 l -4.59,4.6 c -0.39,0.39 -1.01,0.39 -1.4,0 -0.39,-0.39 -0.39,-1.01 0,-1.4 z"
+       id="path493" />
+  </g>
+</svg>


### PR DESCRIPTION
I noticed that there was an icon missing for the "Custom Commands" menu entry for most of the icon themes. I noticed the flat theme was just Google Material fonts recolored so I wen ahead an updated that.

@peterix You may want to update your icon themes at some point as they are also missing this icon.