### PR TITLE
GH-4055 Don't download multiple files to the same path

### DIFF
--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -108,6 +108,10 @@ void PackInstallTask::downloadPack()
         auto relpath = FS::PathCombine("minecraft", file.path, file.name);
         auto path = FS::PathCombine(m_stagingPath, relpath);
 
+        if (filesToCopy.contains(entry->getFullPath())) {
+            qWarning() << "Ignoring" << file.url << "as a file of that path is already downloading.";
+            continue;
+        }
         qDebug() << "Will download" << file.url << "to" << path;
         filesToCopy[entry->getFullPath()] = path;
 


### PR DESCRIPTION
FTB should fix their metadata, but this should resolve issues
downloading their packs at present.
