### PR TITLE
NOISSUE Remove outdated SSL docs

### DIFF
--- a/launcher/minecraft/auth/flows/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/flows/Yggdrasil.cpp
@@ -243,9 +243,7 @@ void Yggdrasil::processReply()
             STATE_FAILED_SOFT,
             tr("<b>SSL Handshake failed.</b><br/>There might be a few causes for it:<br/>"
                "<ul>"
-               "<li>You use Windows XP and need to <a "
-               "href=\"https://www.microsoft.com/en-us/download/details.aspx?id=38918\">update "
-               "your root certificates</a></li>"
+               "<li>You use Windows and need to update your root certificates, please install any outstanding updates.</li>"
                "<li>Some device on your network is interfering with SSL traffic. In that case, "
                "you have bigger worries than Minecraft not starting.</li>"
                "<li>Possibly something else. Check the MultiMC log file for details</li>"


### PR DESCRIPTION
the link is dead and the equivalent newer page is useless, https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn265983(v=ws.11)?redirectedfrom=MSDN#related-content